### PR TITLE
feat: Add OpenTelemetry Integration for Local Development Observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ DEPLOYMENT_GUIDE.md
 # Setup files (contain sensitive tokens)
 setup-process.log
 set-vercel-env.sh
+dev.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ pnpm dev
 - [🎨 Frontend Guide](./docs/frontend.md) - Next.js patterns, components, and data fetching
 - [🗄️ Sanity Backend](./docs/sanity-backend.md) - Schemas, GROQ queries, and Studio development
 - [⚡ Performance](./docs/performance.md) - Optimization techniques and best practices
+- [📊 Observability](./docs/observability.md) - OpenTelemetry integration and tracing
 
 ### Support
 
@@ -39,6 +40,7 @@ pnpm dev
 # Development
 pnpm dev                    # Start all apps
 pnpm dev --filter=web      # Start specific app
+pnpm start                  # Start dev server in background (recommended for AI assistants)
 
 # Code Quality
 pnpm lint                  # Run linter
@@ -70,11 +72,20 @@ SANITY_STUDIO_DATASET=production
 1. **Make Changes**: Edit files, hot reload works automatically
 2. **Check Types**: Run `pnpm check-types` before committing
 3. **Format Code**: Run `pnpm format` to ensure consistency
-3. **Tests**: Run `pnpm test` to check tests
-4. **Generate Types**: After schema changes, run type generation
+4. **Tests**: Run `pnpm test` to check tests
+5. **Generate Types**: After schema changes, run type generation
 
 ## Need Help?
 
 - Check [Troubleshooting Guide](./docs/troubleshooting.md) for common issues
 - Use Vision plugin at `/studio/vision` to test GROQ queries
 - Enable debug logging with `LOG_LEVEL=debug pnpm dev`
+
+## Important Reminders
+
+- **Claude Code Dev Server Fix**: To avoid timeouts when running dev servers:
+  - Use `pnpm start:claude` for a Claude Code-optimized dev server (runs with --no-daemon and --concurrency=1)
+  - Use `pnpm start:background` to run completely in background with logs in `dev.log`
+  - The `start` script now includes automatic port cleanup to prevent conflicts
+- **OpenTelemetry Setup**: The project has OpenTelemetry integration prepared. See [Local Development Guide](./docs/local-development.md) for telemetry configuration details
+- **Sanity Visual Editing**: When working with Sanity's visual editing feature, the `stega` parameter is a valid option for `sanityFetch`. See: https://www.sanity.io/docs/visual-editing/stega

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,4 +28,4 @@ If you have questions or need help, please open an issue.
 
 ---
 
-Thank you for contributing! 
+Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://ra
 Set `SANITY_STUDIO_PRODUCTION_HOSTNAME` to whatever you want your deployed Sanity Studio hostname to be. Eg. for `SANITY_STUDIO_PRODUCTION_HOSTNAME=my-cool-project` you'll get a studio URL of `https://my-cool-project.sanity.studio` (and `<my-branch-name>-my-cool-project.sanity.studio` for PR previews builds done automatically via the `deploy-sanity.yml` github CI workflow when you open a PR.)
 
 Set `SANITY_STUDIO_PRESENTATION_URL` to your web app front-end URL (from the Vercel deployment). This URL is required for production deployments and should be:
+
 - Set in your GitHub repository secrets for CI/CD deployments
 - Set in your local environment if deploying manually with `npx sanity deploy`
 - Not needed for local development, where preview will automatically use http://localhost:3000
@@ -136,5 +137,5 @@ You have the freedom to deploy your Next.js app to your hosting provider of choi
 Now that you've deployed your Next.js application and Sanity Studio, you can optionally invite a collaborator to your Studio. Open up [Manage](https://www.sanity.io/manage), select your project and click "Invite project members"
 
 They will be able to access the deployed Studio, where you can collaborate together on creating content.
-# Deployment fixed
 
+# Deployment fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ We currently provide security updates for version 1.x of this project.
 
 ---
 
-Thanks for helping keep this project secure! 
+Thanks for helping keep this project secure!

--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -10,6 +10,6 @@ export default defineCliConfig({
     projectId: projectId,
     dataset: dataset,
   },
-  studioHost: 'nicklewistheblog',
+  studioHost: "nicklewistheblog",
   autoUpdates: false,
 });

--- a/apps/studio/schemaTypes/documents/blog.test.ts
+++ b/apps/studio/schemaTypes/documents/blog.test.ts
@@ -1,33 +1,33 @@
-import { describe, it, expect } from 'vitest'
-import { blog } from './blog'
+import { describe, it, expect } from "vitest";
+import { blog } from "./blog";
 
-describe('Blog Schema', () => {
-  it('should have correct type and name', () => {
-    expect(blog.type).toBe('document')
-    expect(blog.name).toBe('blog')
-    expect(blog.title).toBe('Blog')
-  })
+describe("Blog Schema", () => {
+  it("should have correct type and name", () => {
+    expect(blog.type).toBe("document");
+    expect(blog.name).toBe("blog");
+    expect(blog.title).toBe("Blog");
+  });
 
-  it('should have required fields', () => {
-    const fieldNames = blog.fields.map(f => f.name)
-    
+  it("should have required fields", () => {
+    const fieldNames = blog.fields.map((f) => f.name);
+
     // Essential fields
-    expect(fieldNames).toContain('title')
-    expect(fieldNames).toContain('slug')
-    expect(fieldNames).toContain('authors')
-    expect(fieldNames).toContain('richText')
-    expect(fieldNames).toContain('publishedAt')
-    expect(fieldNames).toContain('image')
-  })
+    expect(fieldNames).toContain("title");
+    expect(fieldNames).toContain("slug");
+    expect(fieldNames).toContain("authors");
+    expect(fieldNames).toContain("richText");
+    expect(fieldNames).toContain("publishedAt");
+    expect(fieldNames).toContain("image");
+  });
 
-  it('should have proper field validations', () => {
-    const titleField = blog.fields.find(f => f.name === 'title')
-    const slugField = blog.fields.find(f => f.name === 'slug')
-    
+  it("should have proper field validations", () => {
+    const titleField = blog.fields.find((f) => f.name === "title");
+    const slugField = blog.fields.find((f) => f.name === "slug");
+
     // Title should be required
-    expect(titleField?.validation).toBeDefined()
-    
+    expect(titleField?.validation).toBeDefined();
+
     // Slug should be required
-    expect(slugField?.validation).toBeDefined()
-  })
-})
+    expect(slugField?.validation).toBeDefined();
+  });
+});

--- a/apps/studio/schemaTypes/documents/blog.test.ts
+++ b/apps/studio/schemaTypes/documents/blog.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { blog } from "./blog";
 
 describe("Blog Schema", () => {

--- a/apps/studio/schemaTypes/schema.test.ts
+++ b/apps/studio/schemaTypes/schema.test.ts
@@ -1,33 +1,33 @@
-import { describe, it, expect } from 'vitest'
-import { schemaTypes } from './index'
+import { describe, it, expect } from "vitest";
+import { schemaTypes } from "./index";
 
-describe('Sanity Schema', () => {
-  it('should have valid schema types', () => {
-    expect(schemaTypes).toBeDefined()
-    expect(schemaTypes.length).toBeGreaterThan(0)
-  })
+describe("Sanity Schema", () => {
+  it("should have valid schema types", () => {
+    expect(schemaTypes).toBeDefined();
+    expect(schemaTypes.length).toBeGreaterThan(0);
+  });
 
-  it('should have required document types', () => {
-    const typeNames = schemaTypes.map(t => t.name)
-    expect(typeNames).toContain('blog')
-    expect(typeNames).toContain('page')
-    expect(typeNames).toContain('author')
-    expect(typeNames).toContain('homePage')
-    expect(typeNames).toContain('settings')
-  })
+  it("should have required document types", () => {
+    const typeNames = schemaTypes.map((t) => t.name);
+    expect(typeNames).toContain("blog");
+    expect(typeNames).toContain("page");
+    expect(typeNames).toContain("author");
+    expect(typeNames).toContain("homePage");
+    expect(typeNames).toContain("settings");
+  });
 
-  it('should have block types for page builder', () => {
-    const typeNames = schemaTypes.map(t => t.name)
-    expect(typeNames).toContain('hero')
-    expect(typeNames).toContain('cta')
-    expect(typeNames).toContain('faqAccordion')
-    expect(typeNames).toContain('featureCardsIcon')
-  })
+  it("should have block types for page builder", () => {
+    const typeNames = schemaTypes.map((t) => t.name);
+    expect(typeNames).toContain("hero");
+    expect(typeNames).toContain("cta");
+    expect(typeNames).toContain("faqAccordion");
+    expect(typeNames).toContain("featureCardsIcon");
+  });
 
-  it('should have shared object types', () => {
-    const typeNames = schemaTypes.map(t => t.name)
-    expect(typeNames).toContain('button')
-    expect(typeNames).toContain('customUrl')
-    expect(typeNames).toContain('richText')
-  })
-})
+  it("should have shared object types", () => {
+    const typeNames = schemaTypes.map((t) => t.name);
+    expect(typeNames).toContain("button");
+    expect(typeNames).toContain("customUrl");
+    expect(typeNames).toContain("richText");
+  });
+});

--- a/apps/studio/schemaTypes/schema.test.ts
+++ b/apps/studio/schemaTypes/schema.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { schemaTypes } from "./index";
 
 describe("Sanity Schema", () => {

--- a/apps/studio/utils/mock-data.ts
+++ b/apps/studio/utils/mock-data.ts
@@ -241,9 +241,7 @@ function generateFAQBlock(faqs: FAQs) {
   };
 }
 
-export async function checkIfDataExists(
-  client: any,
-): Promise<boolean> {
+export async function checkIfDataExists(client: any): Promise<boolean> {
   const { homePage } = await client.fetch(`{
     "homePage": defined(*[_type == 'homePage' && _id == 'homePage'][0]._id),
   }`);

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node',
-    include: ['**/*.test.ts'],
+    environment: "node",
+    include: ["**/*.test.ts"],
   },
-})
+});

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,14 @@ NEXT_PUBLIC_SANITY_API_VERSION=2024-10-28
 NEXT_PUBLIC_SANITY_STUDIO_URL=http://localhost:3333
 SANITY_API_READ_TOKEN=
 SANITY_API_WRITE_TOKEN=
+
+# OpenTelemetry Configuration
+OTEL_ENABLED=false
+OTEL_SERVICE_NAME=sanity-web-local
+OTEL_LOG_LEVEL=info
+OTEL_EXPORTER=console
+
+# Axiom Configuration (optional, only needed if OTEL_EXPORTER=axiom)
+# AXIOM_API_TOKEN=xaat-your-token-here
+# AXIOM_DATASET=dev-traces
+# AXIOM_DOMAIN=api.axiom.co

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,6 +1,22 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { initializeObservability } = await import('@workspace/observability')
-    initializeObservability()
+  console.log("[Instrumentation] Starting registration...");
+  console.log("[Instrumentation] NEXT_RUNTIME:", process.env.NEXT_RUNTIME);
+  console.log("[Instrumentation] OTEL_ENABLED:", process.env.OTEL_ENABLED);
+  console.log(
+    "[Instrumentation] OTEL_SERVICE_NAME:",
+    process.env.OTEL_SERVICE_NAME,
+  );
+  console.log("[Instrumentation] OTEL_EXPORTER:", process.env.OTEL_EXPORTER);
+
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    console.log("[Instrumentation] Loading observability module...");
+    const { initializeObservability } = await import(
+      "@workspace/observability"
+    );
+    console.log("[Instrumentation] Initializing observability...");
+    initializeObservability();
+    console.log("[Instrumentation] Observability initialized!");
+  } else {
+    console.log("[Instrumentation] Skipping - not in Node.js runtime");
   }
 }

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { initializeObservability } = await import('@workspace/observability')
+    initializeObservability()
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,11 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  transpilePackages: ["@workspace/ui"],
+  transpilePackages: ["@workspace/ui", "@workspace/observability"],
   experimental: {
     reactCompiler: true,
     // ppr: true,
     inlineCss: true,
+    instrumentationHook: true,
   },
   logging: {
     fetches: {},

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,7 +7,6 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
     // ppr: true,
     inlineCss: true,
-    instrumentationHook: true,
   },
   logging: {
     fetches: {},

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "slugify": "^1.6.6"
   },
   "devDependencies": {
+    "@opentelemetry/api": "~1.8.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^24",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@sanity/client": "^7.6.0",
     "@sanity/image-url": "^1.1.0",
     "@sanity/visual-editing": "^2.15.0",
+    "@workspace/observability": "workspace:*",
     "@workspace/ui": "workspace:*",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "lucide-react": "0.525.0",

--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -2,15 +2,14 @@ import { notFound } from "next/navigation";
 
 import { PageBuilder } from "@/components/pagebuilder";
 import { client } from "@/lib/sanity/client";
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { querySlugPageData, querySlugPagePaths } from "@/lib/sanity/query";
 import { getSEOMetadata } from "@/lib/seo";
 
-async function fetchSlugPageData(slug: string, stega = true) {
+async function fetchSlugPageData(slug: string) {
   return await sanityFetch({
     query: querySlugPageData,
     params: { slug: `/${slug}` },
-    stega,
   });
 }
 
@@ -32,7 +31,7 @@ export async function generateMetadata({
 }) {
   const { slug } = await params;
   const slugString = slug.join("/");
-  const { data: pageData } = await fetchSlugPageData(slugString, false);
+  const { data: pageData } = await fetchSlugPageData(slugString);
   return getSEOMetadata(
     pageData
       ? {

--- a/apps/web/src/app/api/axiom-check/route.ts
+++ b/apps/web/src/app/api/axiom-check/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const axiomToken = process.env.AXIOM_API_TOKEN;
+  const axiomDataset = process.env.AXIOM_DATASET;
+  const axiomDomain = process.env.AXIOM_DOMAIN || "api.axiom.co";
+
+  if (!axiomToken || !axiomDataset) {
+    return NextResponse.json(
+      {
+        error: "Axiom not configured",
+        config: {
+          hasToken: !!axiomToken,
+          dataset: axiomDataset,
+          domain: axiomDomain,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // First, check if the dataset exists
+    const datasetResponse = await fetch(
+      `https://${axiomDomain}/v1/datasets/${axiomDataset}`,
+      {
+        headers: {
+          Authorization: `Bearer ${axiomToken}`,
+        },
+      },
+    );
+
+    if (!datasetResponse.ok) {
+      return NextResponse.json(
+        {
+          error: "Failed to access dataset",
+          status: datasetResponse.status,
+          message: await datasetResponse.text(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const datasetInfo = await datasetResponse.json();
+
+    // Query for recent traces
+    const queryResponse = await fetch(
+      `https://${axiomDomain}/v1/datasets/${axiomDataset}/query`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${axiomToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          apl: `dataset | where _time > ago(5m) | where service.name == "${process.env.OTEL_SERVICE_NAME || "unknown"}" | limit 20`,
+          startTime: new Date(Date.now() - 300000).toISOString(), // Last 5 minutes
+          endTime: new Date().toISOString(),
+        }),
+      },
+    );
+
+    if (!queryResponse.ok) {
+      return NextResponse.json(
+        {
+          error: "Query failed",
+          status: queryResponse.status,
+          message: await queryResponse.text(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const queryData = await queryResponse.json();
+
+    // Also check for any traces at all in the last hour
+    const allTracesResponse = await fetch(
+      `https://${axiomDomain}/v1/datasets/${axiomDataset}/query`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${axiomToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          apl: `dataset | where _time > ago(1h) | summarize count = count()`,
+          startTime: new Date(Date.now() - 3600000).toISOString(), // Last hour
+          endTime: new Date().toISOString(),
+        }),
+      },
+    );
+
+    const allTracesData = await allTracesResponse.json();
+
+    return NextResponse.json({
+      success: true,
+      dataset: {
+        name: datasetInfo.name,
+        created: datasetInfo.created,
+      },
+      recentTraces: {
+        count: queryData.matches?.length || 0,
+        serviceName: process.env.OTEL_SERVICE_NAME,
+        traces: queryData.matches?.slice(0, 5).map((trace: any) => ({
+          timestamp: trace._time,
+          traceId: trace.trace?.trace_id,
+          spanName: trace.name,
+          serviceName: trace.service?.name,
+          attributes: trace.attributes,
+        })),
+      },
+      totalTracesLastHour: allTracesData.buckets?.[0]?.count || 0,
+      config: {
+        serviceName: process.env.OTEL_SERVICE_NAME,
+        exporter: process.env.OTEL_EXPORTER,
+        enabled: process.env.OTEL_ENABLED,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "Failed to check Axiom",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/axiom-datasets/route.ts
+++ b/apps/web/src/app/api/axiom-datasets/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const token = process.env.AXIOM_API_TOKEN;
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing API token" });
+  }
+
+  try {
+    const response = await fetch("https://api.axiom.co/v1/datasets", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({
+        error: "Failed to list datasets",
+        status: response.status,
+        message: await response.text(),
+      });
+    }
+
+    const datasets = await response.json();
+
+    return NextResponse.json({
+      success: true,
+      count: datasets.length,
+      datasets: datasets.map((d: any) => ({
+        name: d.name,
+        created: d.created,
+        description: d.description,
+      })),
+      currentDataset: process.env.AXIOM_DATASET,
+      exists: datasets.some((d: any) => d.name === process.env.AXIOM_DATASET),
+    });
+  } catch (error) {
+    return NextResponse.json({
+      error: "Failed to fetch datasets",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function POST() {
+  const token = process.env.AXIOM_API_TOKEN;
+  const datasetName = process.env.AXIOM_DATASET || "dev-traces";
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing API token" });
+  }
+
+  try {
+    const response = await fetch("https://api.axiom.co/v1/datasets", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: datasetName,
+        description: "OpenTelemetry traces for Sanity Next.js development",
+      }),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({
+        error: "Failed to create dataset",
+        status: response.status,
+        message: await response.text(),
+      });
+    }
+
+    const dataset = await response.json();
+
+    return NextResponse.json({
+      success: true,
+      message: `Dataset '${datasetName}' created successfully`,
+      dataset,
+    });
+  } catch (error) {
+    return NextResponse.json({
+      error: "Failed to create dataset",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/web/src/app/api/axiom-test/route.ts
+++ b/apps/web/src/app/api/axiom-test/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const token = process.env.AXIOM_API_TOKEN;
+  const dataset = process.env.AXIOM_DATASET;
+
+  if (!token || !dataset) {
+    return NextResponse.json({ error: "Missing credentials" });
+  }
+
+  try {
+    // Test 1: List datasets
+    const datasetsResponse = await fetch("https://api.axiom.co/v1/datasets", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!datasetsResponse.ok) {
+      return NextResponse.json({
+        error: "Failed to list datasets",
+        status: datasetsResponse.status,
+        message: await datasetsResponse.text(),
+      });
+    }
+
+    const datasets = await datasetsResponse.json();
+
+    // Test 2: Ingest a test event
+    const testEvent = {
+      _time: new Date().toISOString(),
+      test: true,
+      message: "OpenTelemetry test event",
+      service: process.env.OTEL_SERVICE_NAME,
+    };
+
+    const ingestResponse = await fetch(
+      `https://api.axiom.co/v1/datasets/${dataset}/ingest`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([testEvent]),
+      },
+    );
+
+    if (!ingestResponse.ok) {
+      return NextResponse.json({
+        error: "Failed to ingest test event",
+        status: ingestResponse.status,
+        message: await ingestResponse.text(),
+        dataset: dataset,
+      });
+    }
+
+    const ingestResult = await ingestResponse.json();
+
+    return NextResponse.json({
+      success: true,
+      datasets: datasets.map((d: any) => d.name),
+      targetDataset: dataset,
+      datasetExists: datasets.some((d: any) => d.name === dataset),
+      ingestResult,
+      testEvent,
+    });
+  } catch (error) {
+    return NextResponse.json({
+      error: "Failed to test Axiom",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/web/src/app/api/otel-debug/route.ts
+++ b/apps/web/src/app/api/otel-debug/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { trace, context } from "@opentelemetry/api";
+import { isEnabled, getConfig } from "@workspace/observability";
+
+export async function GET() {
+  const config = getConfig();
+  const tracer = trace.getTracer("otel-debug", "1.0.0");
+
+  // Create a test span directly using OpenTelemetry API
+  const span = tracer.startSpan("debug.test.root");
+  const spanContext = span.spanContext();
+
+  try {
+    // Add attributes
+    span.setAttributes({
+      "debug.test": true,
+      "debug.timestamp": Date.now(),
+      "debug.config": JSON.stringify(config),
+    });
+
+    // Create child span
+    await context.with(trace.setSpan(context.active(), span), async () => {
+      const childSpan = tracer.startSpan("debug.test.child");
+      childSpan.setAttribute("child.test", true);
+
+      // Simulate some work
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      childSpan.end();
+    });
+
+    // Force span to end
+    span.end();
+
+    // Give exporter time to send
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    return NextResponse.json({
+      success: true,
+      debug: {
+        otelEnabled: isEnabled(),
+        config: {
+          ...config,
+          axiom: (config as any).axiom
+            ? {
+                ...(config as any).axiom,
+                apiToken: (config as any).axiom.apiToken ? "***" : undefined,
+              }
+            : undefined,
+        },
+        span: {
+          traceId: spanContext.traceId,
+          spanId: spanContext.spanId,
+          isValid: spanContext.traceId !== "00000000000000000000000000000000",
+          traceFlags: spanContext.traceFlags,
+        },
+        environment: {
+          NODE_ENV: process.env.NODE_ENV,
+          NEXT_RUNTIME: process.env.NEXT_RUNTIME,
+          instrumentationRegistered: !!global._otelRegistered,
+        },
+        checks: {
+          configLoaded: !!config,
+          spanCreated: !!span,
+          contextValid:
+            spanContext.traceId !== "00000000000000000000000000000000",
+          exporterConfigured: config.exporter !== "none",
+        },
+      },
+      instructions: {
+        console:
+          "Check your terminal for span output if using console exporter",
+        axiom: "Visit https://app.axiom.co and check your dataset for traces",
+        verify: `Trace ID to search for: ${spanContext.traceId}`,
+      },
+    });
+  } catch (error) {
+    span.recordException(error as Error);
+    span.end();
+
+    return NextResponse.json(
+      {
+        error: "Debug test failed",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+// Mark that instrumentation has been registered
+declare global {
+  var _otelRegistered: boolean | undefined;
+}
+
+if (isEnabled()) {
+  global._otelRegistered = true;
+}

--- a/apps/web/src/app/api/otel-debug/route.ts
+++ b/apps/web/src/app/api/otel-debug/route.ts
@@ -1,6 +1,6 @@
+import { context, trace } from "@opentelemetry/api";
+import { getConfig, isEnabled } from "@workspace/observability";
 import { NextResponse } from "next/server";
-import { trace, context } from "@opentelemetry/api";
-import { isEnabled, getConfig } from "@workspace/observability";
 
 export async function GET() {
   const config = getConfig();

--- a/apps/web/src/app/api/test-telemetry/route.ts
+++ b/apps/web/src/app/api/test-telemetry/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
-import { withSpan, logger } from "@workspace/observability";
 import type { Span } from "@opentelemetry/api";
+import { logger, withSpan } from "@workspace/observability";
+import { NextResponse } from "next/server";
 
 async function queryAxiomForTraces(traceId: string) {
   const axiomToken = process.env.AXIOM_API_TOKEN;

--- a/apps/web/src/app/api/test-telemetry/route.ts
+++ b/apps/web/src/app/api/test-telemetry/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { withSpan, logger } from "@workspace/observability";
+import type { Span } from "@opentelemetry/api";
+
+async function queryAxiomForTraces(traceId: string) {
+  const axiomToken = process.env.AXIOM_API_TOKEN;
+  const axiomDataset = process.env.AXIOM_DATASET;
+
+  if (!axiomToken || !axiomDataset) {
+    return { error: "Axiom credentials not configured" };
+  }
+
+  // Wait a bit for traces to be processed
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  try {
+    // Query Axiom API for the trace
+    const response = await fetch(
+      `https://api.axiom.co/v1/datasets/${axiomDataset}/query`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${axiomToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          apl: `dataset | where trace.trace_id == "${traceId}" | limit 10`,
+          startTime: new Date(Date.now() - 60000).toISOString(), // Last minute
+          endTime: new Date().toISOString(),
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      return {
+        error: "Axiom query failed",
+        status: response.status,
+        message: await response.text(),
+      };
+    }
+
+    const data = await response.json();
+    return {
+      found: data.matches?.length > 0,
+      count: data.matches?.length || 0,
+      traces: data.matches || [],
+    };
+  } catch (error) {
+    return {
+      error: "Failed to query Axiom",
+      details: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function GET() {
+  // Capture the trace ID for verification
+  let capturedTraceId: string | undefined;
+
+  const spanResult = await withSpan(
+    "api.test-telemetry",
+    async (span: Span) => {
+      // Capture trace ID from the span context
+      const spanContext = span.spanContext();
+      capturedTraceId = spanContext.traceId;
+
+      logger.info("Testing telemetry endpoint", { traceId: capturedTraceId });
+
+      // Add some attributes
+      span.setAttribute("test.type", "manual");
+      span.setAttribute("test.timestamp", new Date().toISOString());
+      span.setAttribute("test.unique_id", `test-${Date.now()}`);
+
+      // Simulate some work with nested spans
+      await withSpan(
+        "api.test-telemetry.simulate-work",
+        async (childSpan: Span) => {
+          childSpan.setAttribute("work.duration", 100);
+          childSpan.setAttribute("work.type", "simulation");
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        },
+      );
+
+      // Simulate a calculation
+      const result = await withSpan(
+        "api.test-telemetry.calculate",
+        async (childSpan: Span) => {
+          childSpan.setAttribute("calculation.input", 42);
+          const output = 42 * 2;
+          childSpan.setAttribute("calculation.output", output);
+          childSpan.setAttribute("calculation.formula", "input * 2");
+          return output;
+        },
+      );
+
+      logger.info("Telemetry test completed", {
+        result,
+        traceId: capturedTraceId,
+      });
+
+      return result;
+    },
+  );
+
+  // If using Axiom, verify the trace was sent
+  let axiomVerification = null;
+  if (process.env.OTEL_EXPORTER === "axiom" && capturedTraceId) {
+    logger.info("Verifying trace in Axiom", { traceId: capturedTraceId });
+    axiomVerification = await queryAxiomForTraces(capturedTraceId);
+  }
+
+  return NextResponse.json({
+    success: true,
+    message: "Telemetry test completed",
+    result: spanResult,
+    trace: {
+      enabled: process.env.OTEL_ENABLED === "true",
+      serviceName: process.env.OTEL_SERVICE_NAME,
+      exporter: process.env.OTEL_EXPORTER,
+      traceId: capturedTraceId,
+    },
+    axiomVerification,
+    debug: {
+      env: {
+        OTEL_ENABLED: process.env.OTEL_ENABLED,
+        OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME,
+        OTEL_EXPORTER: process.env.OTEL_EXPORTER,
+        AXIOM_API_TOKEN: process.env.AXIOM_API_TOKEN ? "***" : undefined,
+        AXIOM_DATASET: process.env.AXIOM_DATASET,
+      },
+    },
+  });
+}

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -6,15 +6,14 @@ import { RichText } from "@/components/richtext";
 import { SanityImage } from "@/components/sanity-image";
 import { TableOfContent } from "@/components/table-of-content";
 import { client } from "@/lib/sanity/client";
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { queryBlogPaths, queryBlogSlugPageData } from "@/lib/sanity/query";
 import { getSEOMetadata } from "@/lib/seo";
 
-async function fetchBlogSlugPageData(slug: string, stega = true) {
+async function fetchBlogSlugPageData(slug: string) {
   return await sanityFetch({
     query: queryBlogSlugPageData,
     params: { slug: `/blog/${slug}` },
-    stega,
   });
 }
 
@@ -35,7 +34,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const { data } = await fetchBlogSlugPageData(slug, false);
+  const { data } = await fetchBlogSlugPageData(slug);
   return getSEOMetadata(
     data
       ? {

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { BlogCard, BlogHeader, FeaturedBlogCard } from "@/components/blog-card";
 import { PageBuilder } from "@/components/pagebuilder";
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { queryBlogIndexPageData } from "@/lib/sanity/query";
 import { getSEOMetadata } from "@/lib/seo";
 import { handleErrors } from "@/utils";
@@ -81,7 +81,7 @@ export default async function BlogIndexPage() {
 
         {featuredBlogs.length > 0 && (
           <div className="mx-auto mt-8 sm:mt-12 md:mt-16 mb-12 lg:mb-20 grid grid-cols-1 gap-8 md:gap-12">
-            {featuredBlogs.map((blog) => (
+            {featuredBlogs.map((blog: any) => (
               <FeaturedBlogCard key={blog._id} blog={blog} />
             ))}
           </div>
@@ -89,7 +89,7 @@ export default async function BlogIndexPage() {
 
         {remainingBlogs.length > 0 && (
           <div className="grid grid-cols-1 gap-8 md:gap-12 lg:grid-cols-2 mt-8">
-            {remainingBlogs.map((blog) => (
+            {remainingBlogs.map((blog: any) => (
               <BlogCard key={blog._id} blog={blog} />
             ))}
           </div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { FooterServer, FooterSkeleton } from "@/components/footer";
 import { CombinedJsonLd } from "@/components/json-ld";
 import { NavbarServer, NavbarSkeleton } from "@/components/navbar";
 import { PreviewBar } from "@/components/preview-bar";
-import { SanityLive } from "@/lib/sanity/live";
+import { SanityLive } from "@/lib/sanity/fetch-with-tracing";
 
 import { Providers } from "../components/providers";
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,16 @@
 import { PageBuilder } from "@/components/pagebuilder";
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { queryHomePageData } from "@/lib/sanity/query";
 import { getSEOMetadata } from "@/lib/seo";
 
-async function fetchHomePageData(stega = true) {
+async function fetchHomePageData() {
   return await sanityFetch({
     query: queryHomePageData,
-    stega,
   });
 }
 
 export async function generateMetadata() {
-  const { data: homePageData } = await fetchHomePageData(false);
+  const { data: homePageData } = await fetchHomePageData();
   return getSEOMetadata(
     homePageData
       ? {

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { queryFooterData, queryGlobalSeoSettings } from "@/lib/sanity/query";
 import type {
   QueryFooterDataResult,

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -1,4 +1,4 @@
-import { sanityFetch } from "@/lib/sanity/live";
+import { sanityFetch } from "@/lib/sanity/fetch-with-tracing";
 import { queryGlobalSeoSettings, queryNavbarData } from "@/lib/sanity/query";
 import type {
   QueryGlobalSeoSettingsResult,

--- a/apps/web/src/lib/sanity/fetch-with-tracing.ts
+++ b/apps/web/src/lib/sanity/fetch-with-tracing.ts
@@ -1,7 +1,8 @@
-import { withSpan } from "@workspace/observability";
-import { sanityFetch as originalSanityFetch } from "./live";
-import type { QueryParams } from "next-sanity";
 import type { Span } from "@opentelemetry/api";
+import type { QueryParams } from "next-sanity";
+import { withSpan } from "@workspace/observability";
+
+import { sanityFetch as originalSanityFetch } from "./live";
 
 /**
  * Wrapper around sanityFetch that adds OpenTelemetry tracing

--- a/apps/web/src/lib/sanity/fetch-with-tracing.ts
+++ b/apps/web/src/lib/sanity/fetch-with-tracing.ts
@@ -1,0 +1,57 @@
+import { withSpan } from "@workspace/observability";
+import { sanityFetch as originalSanityFetch } from "./live";
+import type { QueryParams } from "next-sanity";
+import type { Span } from "@opentelemetry/api";
+
+/**
+ * Wrapper around sanityFetch that adds OpenTelemetry tracing
+ */
+export async function sanityFetch<T = any>(options: {
+  query: string;
+  params?: QueryParams;
+  tags?: string[];
+  stega?: boolean;
+}): Promise<T> {
+  const { query, params = {}, tags, stega } = options;
+
+  return withSpan(
+    "sanity.fetch",
+    async (span: Span) => {
+      // Add attributes to the span
+      span.setAttributes({
+        "sanity.query": query.slice(0, 200), // Truncate long queries
+        "sanity.params": JSON.stringify(params).slice(0, 200),
+        "sanity.tags": tags?.join(",") || "",
+      });
+
+      const result = (await originalSanityFetch({
+        query,
+        params,
+        tags,
+        stega,
+      })) as T;
+
+      // Add result metadata
+      if (result && typeof result === "object") {
+        if (Array.isArray(result)) {
+          span.setAttribute("sanity.result.count", result.length);
+        }
+        span.setAttribute(
+          "sanity.result.type",
+          Array.isArray(result) ? "array" : "object",
+        );
+      }
+
+      return result;
+    },
+    {
+      attributes: {
+        "db.system": "sanity",
+        "db.operation": "query",
+      },
+    },
+  );
+}
+
+// Re-export SanityLive
+export { SanityLive } from "./live";

--- a/docs/github-secrets.md
+++ b/docs/github-secrets.md
@@ -14,6 +14,7 @@ The project uses GitHub secrets to securely store environment variables for diff
 ## Secret Categories
 
 ### 1. Sanity Configuration
+
 - `NEXT_PUBLIC_SANITY_PROJECT_ID`: Your Sanity project ID
 - `NEXT_PUBLIC_SANITY_DATASET`: Dataset name (preview/production)
 - `NEXT_PUBLIC_SANITY_API_VERSION`: API version date
@@ -27,6 +28,7 @@ The project uses GitHub secrets to securely store environment variables for diff
 - `SANITY_STUDIO_TITLE`: Studio title
 
 ### 2. Logging Configuration
+
 - `LOG_LEVEL`: Logging level (debug/info/warn/error)
 - `LOG_DIR`: Directory for log files
 - `ENABLE_FILE_LOGS`: Whether to write logs to files
@@ -34,11 +36,13 @@ The project uses GitHub secrets to securely store environment variables for diff
 - `EDGE_LOG_ENDPOINT`: Endpoint for edge logs
 
 ### 3. Runtime Configuration
+
 - `NODE_ENV`: Environment (preview/production)
 - `NEXT_RUNTIME`: Next.js runtime (nodejs/edge)
 - `HOST_NAME`: Application hostname
 
 ### 4. Repository-Level Secrets
+
 - `SANITY_DEPLOY_TOKEN`: Token for deploying Sanity Studio
 - `VERCEL_TOKEN`: Vercel deployment token (optional)
 - `VERCEL_ORG_ID`: Vercel organization ID (optional)
@@ -109,7 +113,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Preview' }}
-    
+
     steps:
       - name: Build
         env:
@@ -129,14 +133,17 @@ jobs:
 ## Troubleshooting
 
 ### Secret not found
+
 - Ensure the secret name matches exactly (case-sensitive)
 - Verify the environment is specified correctly
 - Check that the workflow has the correct environment specified
 
 ### Permission denied
+
 - Ensure you have admin access to the repository
 - For organization repos, check organization secret policies
 
 ### Workflow can't access secrets
+
 - Add `environment: Production` or `environment: Preview` to the job
 - Ensure the branch protection rules allow the workflow to run

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,273 @@
+# Observability Guide
+
+This project includes comprehensive OpenTelemetry integration for monitoring and debugging during development.
+
+## Quick Start
+
+1. **Enable telemetry in your `.env.local`:**
+
+```bash
+# apps/web/.env.local
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-local
+OTEL_EXPORTER=console
+OTEL_LOG_LEVEL=debug
+```
+
+2. **Start the dev server:**
+
+```bash
+pnpm dev
+```
+
+You'll see trace output in your console showing:
+
+- HTTP requests
+- Database queries (Sanity fetches)
+- Server component renders
+- Custom operations
+
+## Understanding Traces
+
+### Console Output Format
+
+When using the console exporter, traces appear as structured JSON:
+
+```json
+{
+  "traceId": "abc123...",
+  "parentId": "def456...",
+  "name": "sanity.fetch",
+  "kind": "CLIENT",
+  "timestamp": 1234567890,
+  "duration": 123.45,
+  "attributes": {
+    "sanity.query": "*[_type == 'post'][0...10]",
+    "sanity.result.count": 10
+  }
+}
+```
+
+### Key Trace Components
+
+- **traceId**: Unique identifier for the entire request flow
+- **spanId**: Unique identifier for this specific operation
+- **parentId**: Links to parent operation (shows hierarchy)
+- **duration**: Time in milliseconds
+- **attributes**: Custom metadata about the operation
+
+## Custom Instrumentation
+
+### Instrumenting Data Fetches
+
+The project automatically instruments Sanity fetches:
+
+```typescript
+// This is automatically traced
+const posts = await sanityFetch({
+  query: `*[_type == "post"]`,
+  tags: ["posts"],
+});
+```
+
+### Adding Custom Spans
+
+For other operations, add custom spans:
+
+```typescript
+import { withSpan } from "@workspace/observability";
+
+// Trace image processing
+const optimizedImage = await withSpan("image.optimize", async (span) => {
+  span.setAttribute("image.size", imageSize);
+  span.setAttribute("image.format", "webp");
+
+  const result = await optimizeImage(originalImage);
+
+  span.setAttribute("image.optimized.size", result.size);
+  return result;
+});
+```
+
+### Tracing API Routes
+
+```typescript
+// app/api/webhook/route.ts
+import { withSpan } from "@workspace/observability";
+
+export async function POST(request: Request) {
+  return withSpan("webhook.process", async (span) => {
+    const payload = await request.json();
+    span.setAttribute("webhook.type", payload.type);
+
+    // Process webhook...
+
+    return Response.json({ success: true });
+  });
+}
+```
+
+## Using Axiom for Cloud Telemetry
+
+For a more powerful telemetry experience:
+
+1. **Create an Axiom account** at https://axiom.co
+2. **Create a dataset** (e.g., "sanity-dev")
+3. **Generate an API token**
+4. **Update your `.env.local`:**
+
+```bash
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-dev
+OTEL_EXPORTER=axiom
+AXIOM_API_TOKEN=xaat-your-token-here
+AXIOM_DATASET=sanity-dev
+```
+
+5. **View traces** at https://app.axiom.co
+
+## Common Patterns
+
+### Tracing Cache Operations
+
+```typescript
+const cachedData = await withSpan("cache.get", async (span) => {
+  span.setAttribute("cache.key", cacheKey);
+
+  const result = await cache.get(cacheKey);
+  span.setAttribute("cache.hit", !!result);
+
+  return result;
+});
+```
+
+### Tracing External API Calls
+
+```typescript
+const apiResult = await withSpan("api.external", async (span) => {
+  span.setAttribute("api.url", apiUrl);
+  span.setAttribute("api.method", "GET");
+
+  const response = await fetch(apiUrl);
+  span.setAttribute("api.status", response.status);
+
+  return response.json();
+});
+```
+
+### Error Tracking
+
+Errors are automatically captured in spans:
+
+```typescript
+await withSpan("risky.operation", async (span) => {
+  try {
+    return await riskyOperation();
+  } catch (error) {
+    // Error is automatically recorded
+    // Just re-throw it
+    throw error;
+  }
+});
+```
+
+## Performance Considerations
+
+### Development Mode
+
+- Console exporter has minimal overhead
+- All operations are traced (no sampling)
+- Detailed attributes included
+
+### Production Mode
+
+- Set `OTEL_ENABLED=false` for zero overhead
+- Or use Axiom with sampling for production monitoring
+- Consider which attributes to include (avoid PII)
+
+## Debugging Tips
+
+### No Traces Appearing
+
+1. Check `OTEL_ENABLED=true` in environment
+2. Verify `instrumentation.ts` is loading (check console logs)
+3. Ensure `instrumentationHook: true` in Next.js config
+
+### Missing Custom Traces
+
+1. Import from `@workspace/observability` not other packages
+2. Ensure async operations use `await withSpan`
+3. Check span is ending (no infinite operations)
+
+### Axiom Connection Issues
+
+1. Verify API token is correct
+2. Check dataset exists
+3. Look for network errors in console
+4. Try console exporter first to verify setup
+
+## Best Practices
+
+1. **Semantic Naming**: Use dot notation (e.g., `database.query`, `cache.get`)
+2. **Consistent Attributes**: Use standard attribute names across your app
+3. **Avoid PII**: Don't include personal data in traces
+4. **Measure What Matters**: Focus on user-facing operations
+5. **Use Span Links**: Connect related operations across services
+
+## Example: Full Request Trace
+
+Here's what a typical page load might look like:
+
+```
+GET /blog
+├── sanity.fetch (120ms)
+│   └── attributes: { query: "*[_type == 'post']" }
+├── image.optimize (45ms)
+│   └── attributes: { format: "webp", count: 5 }
+└── render.page (200ms)
+    └── attributes: { component: "BlogIndex" }
+```
+
+Total request time: 365ms
+
+## Advanced Usage
+
+### Custom Span Processors
+
+```typescript
+// packages/observability/src/processors/custom.ts
+export class CustomSpanProcessor implements SpanProcessor {
+  onStart(span: Span): void {
+    // Add default attributes
+    span.setAttribute("app.version", process.env.APP_VERSION);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    // Custom processing
+    if (span.duration > 1000) {
+      logger.warn("Slow operation detected", {
+        operation: span.name,
+        duration: span.duration,
+      });
+    }
+  }
+}
+```
+
+### Correlation with Logs
+
+All logs automatically include trace context:
+
+```typescript
+logger.info("Processing payment", { amount: 100 });
+// Output includes traceId and spanId automatically
+```
+
+Use this to correlate logs with traces in Axiom.
+
+## Resources
+
+- [OpenTelemetry Docs](https://opentelemetry.io/docs/)
+- [Axiom Docs](https://axiom.co/docs)
+- [Next.js Instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation)
+- Package README: `packages/observability/README.md`

--- a/docs/telemetry-troubleshooting.md
+++ b/docs/telemetry-troubleshooting.md
@@ -1,0 +1,277 @@
+# Telemetry Troubleshooting Guide
+
+## Testing Your Setup
+
+### 1. Basic Health Check
+
+```bash
+# Test if telemetry is working
+curl http://localhost:3000/api/otel-debug
+```
+
+This endpoint will:
+
+- Create test spans using OpenTelemetry directly
+- Return the trace ID for verification
+- Show your current configuration
+
+### 2. Full Telemetry Test
+
+```bash
+# Test with Axiom verification
+curl http://localhost:3000/api/test-telemetry
+```
+
+This endpoint will:
+
+- Create nested spans with attributes
+- Query Axiom to verify the trace arrived (if using Axiom)
+- Show debug information about your setup
+
+### 3. Check Axiom Connection
+
+```bash
+# Verify Axiom dataset and recent traces
+curl http://localhost:3000/api/axiom-check
+```
+
+This endpoint will:
+
+- Verify your Axiom credentials work
+- Show recent traces from your service
+- Count total traces in the last hour
+
+## Common Issues and Solutions
+
+### No Traces in Console
+
+1. **Check OTEL_ENABLED**
+
+   ```bash
+   # In apps/web/.env.local
+   OTEL_ENABLED=true  # Must be exactly "true"
+   ```
+
+2. **Verify Instrumentation Hook**
+   - Check `apps/web/next.config.ts` has `instrumentationHook: true`
+   - Restart the dev server after changing
+
+3. **Check Console Output**
+   Look for these messages on startup:
+   ```
+   [Instrumentation] Starting registration...
+   [Instrumentation] Loading observability module...
+   [Instrumentation] Observability initialized!
+   ```
+
+### No Traces in Axiom
+
+1. **Verify Environment Variables**
+
+   ```bash
+   # All three must be set
+   OTEL_EXPORTER=axiom
+   AXIOM_API_TOKEN=xaat-your-token
+   AXIOM_DATASET=your-dataset-name
+   ```
+
+2. **Check Token Permissions**
+   - Token needs write access to the dataset
+   - Test with: `curl http://localhost:3000/api/axiom-check`
+
+3. **Verify Dataset Exists**
+   - Log into Axiom UI
+   - Check dataset name matches exactly (case-sensitive)
+
+4. **Check for Errors**
+   ```bash
+   # Look for export errors in console
+   OTEL_LOG_LEVEL=debug pnpm dev
+   ```
+
+### Traces Not Linking Properly
+
+1. **Context Propagation**
+
+   ```typescript
+   // BAD - Context lost
+   async function doWork() {
+     const span = createSpan("work");
+     await someAsyncWork();
+     span.end();
+   }
+
+   // GOOD - Context preserved
+   async function doWork() {
+     return withSpan("work", async (span) => {
+       await someAsyncWork();
+     });
+   }
+   ```
+
+2. **Check Trace IDs**
+   - Use `/api/otel-debug` to get trace ID
+   - Search in Axiom with: `trace.trace_id == "your-trace-id"`
+
+### Performance Issues
+
+1. **Disable in Production**
+
+   ```bash
+   # Production .env
+   OTEL_ENABLED=false
+   ```
+
+2. **Reduce Span Creation**
+
+   ```typescript
+   // Only trace important operations
+   if (isImportantOperation) {
+     return withSpan("important.op", async () => {
+       // ...
+     });
+   }
+   ```
+
+3. **Use Sampling** (future enhancement)
+
+## Debugging Commands
+
+### Check Current Configuration
+
+```typescript
+// Add to any file temporarily
+import { getConfig, isEnabled } from "@workspace/observability";
+console.log("OTEL Config:", getConfig());
+console.log("OTEL Enabled:", isEnabled());
+```
+
+### Manual Span Test
+
+```typescript
+// Test span creation directly
+import { createSpan } from "@workspace/observability";
+
+const span = createSpan("manual.test");
+span.setAttribute("test", true);
+span.end();
+```
+
+### Force Flush
+
+```typescript
+// In API routes, ensure spans are flushed
+export async function GET() {
+  const result = await withSpan("api.endpoint", async () => {
+    // Your logic
+  });
+
+  // Give time for export
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  return Response.json(result);
+}
+```
+
+## Axiom Specific
+
+### Query Language (APL)
+
+Find your traces:
+
+```apl
+dataset
+| where service.name == "sanity-web-local"
+| where _time > ago(5m)
+```
+
+Find specific trace:
+
+```apl
+dataset
+| where trace.trace_id == "your-trace-id"
+```
+
+Find errors:
+
+```apl
+dataset
+| where status.code == 2  // Error status
+| where service.name == "sanity-web-local"
+```
+
+### Axiom Dashboard
+
+1. Go to https://app.axiom.co
+2. Select your dataset
+3. Use "Traces" view for span visualization
+4. Use "Stream" view for raw data
+
+## Environment-Specific Setup
+
+### Local Development
+
+```bash
+# Recommended for local dev
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-local
+OTEL_EXPORTER=console
+OTEL_LOG_LEVEL=info
+```
+
+### Local with Axiom
+
+```bash
+# For testing Axiom integration
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-dev
+OTEL_EXPORTER=axiom
+OTEL_LOG_LEVEL=debug
+AXIOM_API_TOKEN=xaat-...
+AXIOM_DATASET=dev-traces
+```
+
+### CI/CD
+
+```bash
+# Disable for CI
+OTEL_ENABLED=false
+```
+
+## Verification Checklist
+
+- [ ] `OTEL_ENABLED=true` in environment
+- [ ] `instrumentationHook: true` in next.config.ts
+- [ ] Observability package built (`pnpm build` in packages/observability)
+- [ ] Dev server restarted after config changes
+- [ ] Console shows initialization messages
+- [ ] Test endpoints return trace IDs
+- [ ] Axiom credentials are correct (if using Axiom)
+- [ ] Dataset exists and is writable (if using Axiom)
+
+## Still Not Working?
+
+1. **Full Reset**
+
+   ```bash
+   # Clean and rebuild
+   rm -rf node_modules packages/*/node_modules
+   pnpm install
+   cd packages/observability && pnpm build
+   pnpm dev
+   ```
+
+2. **Enable Debug Logging**
+
+   ```bash
+   OTEL_LOG_LEVEL=debug pnpm dev
+   ```
+
+3. **Check Next.js Logs**
+   - Look for errors during instrumentation
+   - Check for module resolution issues
+
+4. **Test Minimal Setup**
+   - Try console exporter first
+   - Add one span at a time
+   - Verify each step works

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
+    "start": "./scripts/start-dev.sh",
+    "start:background": "nohup ./scripts/start-dev.sh > dev.log 2>&1 &",
+    "start:claude": "turbo dev --no-daemon --concurrency=4",
     "lint": "turbo lint",
     "check-types": "turbo check-types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
     "test:ui": "vitest --ui",
-    "validate": "turbo run lint check-types test"
+    "validate": "turbo run lint check-types test",
+    "postinstall": "turbo build --filter=@workspace/*"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -47,9 +47,11 @@ AXIOM_DOMAIN=api.axiom.co        # Optional: Axiom API domain
 
 ```typescript
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { initializeObservability } = await import('@workspace/observability')
-    initializeObservability()
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { initializeObservability } = await import(
+      "@workspace/observability"
+    );
+    initializeObservability();
   }
 }
 ```
@@ -61,8 +63,8 @@ const nextConfig = {
   experimental: {
     instrumentationHook: true,
   },
-  transpilePackages: ['@workspace/observability'],
-}
+  transpilePackages: ["@workspace/observability"],
+};
 ```
 
 ## Usage
@@ -70,6 +72,7 @@ const nextConfig = {
 ### Automatic Instrumentation
 
 Once configured, OpenTelemetry automatically instruments:
+
 - HTTP requests (incoming and outgoing)
 - Database queries
 - Next.js server components
@@ -78,38 +81,42 @@ Once configured, OpenTelemetry automatically instruments:
 ### Custom Spans
 
 ```typescript
-import { withSpan, createSpan, setSpanAttributes } from '@workspace/observability'
+import {
+  withSpan,
+  createSpan,
+  setSpanAttributes,
+} from "@workspace/observability";
 
 // Async function with automatic span management
-const result = await withSpan('fetch-user-data', async (span) => {
-  setSpanAttributes(span, { userId: '123' })
-  const user = await fetchUser('123')
-  return user
-})
+const result = await withSpan("fetch-user-data", async (span) => {
+  setSpanAttributes(span, { userId: "123" });
+  const user = await fetchUser("123");
+  return user;
+});
 
 // Manual span management
-const span = createSpan('process-payment')
+const span = createSpan("process-payment");
 try {
-  span.setAttribute('amount', 100)
-  await processPayment()
-  span.setStatus({ code: SpanStatusCode.OK })
+  span.setAttribute("amount", 100);
+  await processPayment();
+  span.setStatus({ code: SpanStatusCode.OK });
 } catch (error) {
-  span.recordException(error)
-  throw error
+  span.recordException(error);
+  throw error;
 } finally {
-  span.end()
+  span.end();
 }
 ```
 
 ### Structured Logging
 
 ```typescript
-import { logger } from '@workspace/observability'
+import { logger } from "@workspace/observability";
 
 // Logs include trace context automatically
-logger.info('User logged in', { userId: '123' })
-logger.warn('Rate limit approaching', { remaining: 10 })
-logger.error('Payment failed', { error: error.message })
+logger.info("User logged in", { userId: "123" });
+logger.warn("Rate limit approaching", { remaining: 10 });
+logger.error("Payment failed", { error: error.message });
 ```
 
 ## Development Workflow
@@ -124,6 +131,7 @@ OTEL_LOG_LEVEL=debug
 ```
 
 Output appears in your terminal with structured format:
+
 ```
 [2024-01-01T12:00:00.000Z] [INFO] User logged in {"userId":"123","traceId":"abc123","spanId":"def456"}
 ```
@@ -159,25 +167,28 @@ OTEL_ENABLED=false
 ### Check if OpenTelemetry is Running
 
 ```typescript
-import { isEnabled, getConfig } from '@workspace/observability'
+import { isEnabled, getConfig } from "@workspace/observability";
 
-console.log('OTEL enabled:', isEnabled())
-console.log('OTEL config:', getConfig())
+console.log("OTEL enabled:", isEnabled());
+console.log("OTEL config:", getConfig());
 ```
 
 ### Common Issues
 
 **No telemetry data appearing:**
+
 - Verify `OTEL_ENABLED=true`
 - Check console for initialization messages
 - Ensure `instrumentationHook` is enabled in Next.js config
 
 **Axiom export failing:**
+
 - Verify API token and dataset are correct
 - Check network connectivity to Axiom
 - Look for error messages in console
 
 **Performance impact:**
+
 - Ensure `OTEL_ENABLED=false` in production
 - Use sampling for high-traffic scenarios
 - Monitor span creation in hot paths

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,0 +1,214 @@
+# @workspace/observability
+
+Centralized OpenTelemetry integration for the Sanity + Next.js monorepo, providing comprehensive observability for local development.
+
+## Features
+
+- **Centralized Configuration**: Single package managing all telemetry configuration
+- **Environment-Based Control**: Easy on/off switching via environment variables
+- **Multiple Exporters**: Console (local dev) and Axiom (cloud) support
+- **Zero Overhead When Disabled**: No performance impact when `OTEL_ENABLED=false`
+- **Developer-Friendly**: Human-readable console output for local debugging
+- **Type-Safe**: Full TypeScript support with utility functions
+
+## Installation
+
+This package is already included in the monorepo. To use it in a new app:
+
+```bash
+# Add to your app's package.json
+"@workspace/observability": "workspace:*"
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Master control
+OTEL_ENABLED=true|false          # Enable/disable all telemetry
+
+# Service configuration
+OTEL_SERVICE_NAME=my-service     # Service identifier
+OTEL_LOG_LEVEL=debug|info|warn|error  # Logging verbosity
+
+# Export configuration
+OTEL_EXPORTER=console|axiom|none  # Where to send telemetry data
+
+# Axiom configuration (when OTEL_EXPORTER=axiom)
+AXIOM_API_TOKEN=xaat-...         # Your Axiom API token
+AXIOM_DATASET=my-dataset         # Axiom dataset name
+AXIOM_DOMAIN=api.axiom.co        # Optional: Axiom API domain
+```
+
+### Next.js Integration
+
+1. Create `instrumentation.ts` in your Next.js app root:
+
+```typescript
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { initializeObservability } = await import('@workspace/observability')
+    initializeObservability()
+  }
+}
+```
+
+2. Enable instrumentation in `next.config.ts`:
+
+```typescript
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+  transpilePackages: ['@workspace/observability'],
+}
+```
+
+## Usage
+
+### Automatic Instrumentation
+
+Once configured, OpenTelemetry automatically instruments:
+- HTTP requests (incoming and outgoing)
+- Database queries
+- Next.js server components
+- API routes
+
+### Custom Spans
+
+```typescript
+import { withSpan, createSpan, setSpanAttributes } from '@workspace/observability'
+
+// Async function with automatic span management
+const result = await withSpan('fetch-user-data', async (span) => {
+  setSpanAttributes(span, { userId: '123' })
+  const user = await fetchUser('123')
+  return user
+})
+
+// Manual span management
+const span = createSpan('process-payment')
+try {
+  span.setAttribute('amount', 100)
+  await processPayment()
+  span.setStatus({ code: SpanStatusCode.OK })
+} catch (error) {
+  span.recordException(error)
+  throw error
+} finally {
+  span.end()
+}
+```
+
+### Structured Logging
+
+```typescript
+import { logger } from '@workspace/observability'
+
+// Logs include trace context automatically
+logger.info('User logged in', { userId: '123' })
+logger.warn('Rate limit approaching', { remaining: 10 })
+logger.error('Payment failed', { error: error.message })
+```
+
+## Development Workflow
+
+### Local Development (Console Output)
+
+```bash
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-local
+OTEL_EXPORTER=console
+OTEL_LOG_LEVEL=debug
+```
+
+Output appears in your terminal with structured format:
+```
+[2024-01-01T12:00:00.000Z] [INFO] User logged in {"userId":"123","traceId":"abc123","spanId":"def456"}
+```
+
+### Local with Axiom
+
+```bash
+OTEL_ENABLED=true
+OTEL_SERVICE_NAME=sanity-web-dev
+OTEL_EXPORTER=axiom
+AXIOM_API_TOKEN=xaat-...
+AXIOM_DATASET=dev-traces
+```
+
+View traces in Axiom dashboard: https://app.axiom.co
+
+### Production (Disabled by Default)
+
+```bash
+OTEL_ENABLED=false
+```
+
+## Best Practices
+
+1. **Use Semantic Names**: Name spans descriptively (e.g., `fetch-user-profile` not `fetch`)
+2. **Add Context**: Include relevant attributes (user IDs, request IDs, etc.)
+3. **Handle Errors**: Always record exceptions in spans
+4. **Avoid Over-Instrumentation**: Focus on key operations and user journeys
+5. **Test Performance**: Verify minimal overhead in production scenarios
+
+## Debugging
+
+### Check if OpenTelemetry is Running
+
+```typescript
+import { isEnabled, getConfig } from '@workspace/observability'
+
+console.log('OTEL enabled:', isEnabled())
+console.log('OTEL config:', getConfig())
+```
+
+### Common Issues
+
+**No telemetry data appearing:**
+- Verify `OTEL_ENABLED=true`
+- Check console for initialization messages
+- Ensure `instrumentationHook` is enabled in Next.js config
+
+**Axiom export failing:**
+- Verify API token and dataset are correct
+- Check network connectivity to Axiom
+- Look for error messages in console
+
+**Performance impact:**
+- Ensure `OTEL_ENABLED=false` in production
+- Use sampling for high-traffic scenarios
+- Monitor span creation in hot paths
+
+## API Reference
+
+### Configuration
+
+- `getConfig()`: Get current configuration
+- `isEnabled()`: Check if telemetry is enabled
+- `shouldLog(level)`: Check if logging level is active
+
+### Tracing
+
+- `createSpan(name, options?)`: Create a new span
+- `withSpan(name, fn, options?)`: Execute function with span
+- `withSpanSync(name, fn, options?)`: Sync version of withSpan
+- `setSpanAttribute(span, key, value)`: Set single attribute
+- `setSpanAttributes(span, attributes)`: Set multiple attributes
+
+### Logging
+
+- `logger.debug(message, context?)`
+- `logger.info(message, context?)`
+- `logger.warn(message, context?)`
+- `logger.error(message, context?)`
+
+## Future Enhancements
+
+- [ ] Metrics collection (response times, cache hits)
+- [ ] Custom Sanity Studio integration
+- [ ] Sampling configuration
+- [ ] Additional exporters (Jaeger, Zipkin)
+- [ ] Performance profiling integration

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@workspace/observability",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "~1.8.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",
+    "@opentelemetry/resources": "^1.22.0",
+    "@opentelemetry/sdk-node": "^0.49.1",
+    "@opentelemetry/sdk-trace-base": "^1.22.0",
+    "@opentelemetry/sdk-trace-node": "^1.22.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0",
+    "@vercel/otel": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "@workspace/typescript-config": "workspace:*",
+    "tsup": "^8.2.3",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -2,14 +2,15 @@
   "name": "@workspace/observability",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "scripts": {

--- a/packages/observability/src/__tests__/config.test.ts
+++ b/packages/observability/src/__tests__/config.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getConfig, isEnabled, shouldLog } from "../config";
+
+describe("Observability Config", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("isEnabled", () => {
+    it('should return true when OTEL_ENABLED is "true"', () => {
+      process.env.OTEL_ENABLED = "true";
+      expect(isEnabled()).toBe(true);
+    });
+
+    it('should return false when OTEL_ENABLED is not "true"', () => {
+      process.env.OTEL_ENABLED = "false";
+      expect(isEnabled()).toBe(false);
+    });
+
+    it("should return false when OTEL_ENABLED is undefined", () => {
+      delete process.env.OTEL_ENABLED;
+      expect(isEnabled()).toBe(false);
+    });
+  });
+
+  describe("getConfig", () => {
+    it("should return default config when no env vars are set", () => {
+      const config = getConfig();
+      expect(config).toEqual({
+        enabled: false,
+        serviceName: "unknown-service",
+        logLevel: "info",
+        exporter: "console",
+      });
+    });
+
+    it("should use environment variables when set", () => {
+      process.env.OTEL_ENABLED = "true";
+      process.env.OTEL_SERVICE_NAME = "test-service";
+      process.env.OTEL_LOG_LEVEL = "debug";
+      process.env.OTEL_EXPORTER = "none";
+
+      const config = getConfig();
+      expect(config).toEqual({
+        enabled: true,
+        serviceName: "test-service",
+        logLevel: "debug",
+        exporter: "none",
+      });
+    });
+
+    it("should configure Axiom when exporter is axiom and credentials are provided", () => {
+      process.env.OTEL_ENABLED = "true";
+      process.env.OTEL_EXPORTER = "axiom";
+      process.env.AXIOM_API_TOKEN = "test-token";
+      process.env.AXIOM_DATASET = "test-dataset";
+      process.env.AXIOM_DOMAIN = "test.axiom.co";
+
+      const config = getConfig();
+      expect(config.exporter).toBe("axiom");
+      expect(config.axiom).toEqual({
+        apiToken: "test-token",
+        dataset: "test-dataset",
+        domain: "test.axiom.co",
+      });
+    });
+
+    it("should fall back to console when Axiom credentials are missing", () => {
+      process.env.OTEL_ENABLED = "true";
+      process.env.OTEL_EXPORTER = "axiom";
+      // Missing AXIOM_API_TOKEN and AXIOM_DATASET
+
+      const config = getConfig();
+      expect(config.exporter).toBe("console");
+      expect(config.axiom).toBeUndefined();
+    });
+  });
+
+  describe("shouldLog", () => {
+    beforeEach(() => {
+      process.env.OTEL_ENABLED = "true";
+    });
+
+    it("should return false when disabled", () => {
+      process.env.OTEL_ENABLED = "false";
+      expect(shouldLog("debug")).toBe(false);
+    });
+
+    it("should respect log level hierarchy", () => {
+      process.env.OTEL_LOG_LEVEL = "warn";
+
+      expect(shouldLog("debug")).toBe(false);
+      expect(shouldLog("info")).toBe(false);
+      expect(shouldLog("warn")).toBe(true);
+      expect(shouldLog("error")).toBe(true);
+    });
+
+    it("should log all levels when set to debug", () => {
+      process.env.OTEL_LOG_LEVEL = "debug";
+
+      expect(shouldLog("debug")).toBe(true);
+      expect(shouldLog("info")).toBe(true);
+      expect(shouldLog("warn")).toBe(true);
+      expect(shouldLog("error")).toBe(true);
+    });
+  });
+});

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -1,0 +1,61 @@
+export interface ObservabilityConfig {
+  enabled: boolean
+  serviceName: string
+  logLevel: 'debug' | 'info' | 'warn' | 'error'
+  exporter: 'console' | 'axiom' | 'none'
+  axiom?: {
+    apiToken: string
+    dataset: string
+    domain?: string
+  }
+}
+
+export function getConfig(): ObservabilityConfig {
+  const enabled = process.env.OTEL_ENABLED === 'true'
+  const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown-service'
+  const logLevel = (process.env.OTEL_LOG_LEVEL || 'info') as ObservabilityConfig['logLevel']
+  const exporter = (process.env.OTEL_EXPORTER || 'console') as ObservabilityConfig['exporter']
+
+  const config: ObservabilityConfig = {
+    enabled,
+    serviceName,
+    logLevel,
+    exporter,
+  }
+
+  // Add Axiom config if using Axiom exporter
+  if (exporter === 'axiom') {
+    const apiToken = process.env.AXIOM_API_TOKEN
+    const dataset = process.env.AXIOM_DATASET
+
+    if (!apiToken || !dataset) {
+      console.warn(
+        'Axiom exporter configured but AXIOM_API_TOKEN or AXIOM_DATASET not set. Falling back to console exporter.'
+      )
+      config.exporter = 'console'
+    } else {
+      config.axiom = {
+        apiToken,
+        dataset,
+        domain: process.env.AXIOM_DOMAIN || 'api.axiom.co',
+      }
+    }
+  }
+
+  return config
+}
+
+export function isEnabled(): boolean {
+  return process.env.OTEL_ENABLED === 'true'
+}
+
+export function shouldLog(level: ObservabilityConfig['logLevel']): boolean {
+  if (!isEnabled()) return false
+
+  const config = getConfig()
+  const levels: ObservabilityConfig['logLevel'][] = ['debug', 'info', 'warn', 'error']
+  const configLevelIndex = levels.indexOf(config.logLevel)
+  const requestedLevelIndex = levels.indexOf(level)
+
+  return requestedLevelIndex >= configLevelIndex
+}

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -1,61 +1,68 @@
 export interface ObservabilityConfig {
-  enabled: boolean
-  serviceName: string
-  logLevel: 'debug' | 'info' | 'warn' | 'error'
-  exporter: 'console' | 'axiom' | 'none'
+  enabled: boolean;
+  serviceName: string;
+  logLevel: "debug" | "info" | "warn" | "error";
+  exporter: "console" | "axiom" | "none";
   axiom?: {
-    apiToken: string
-    dataset: string
-    domain?: string
-  }
+    apiToken: string;
+    dataset: string;
+    domain?: string;
+  };
 }
 
 export function getConfig(): ObservabilityConfig {
-  const enabled = process.env.OTEL_ENABLED === 'true'
-  const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown-service'
-  const logLevel = (process.env.OTEL_LOG_LEVEL || 'info') as ObservabilityConfig['logLevel']
-  const exporter = (process.env.OTEL_EXPORTER || 'console') as ObservabilityConfig['exporter']
+  const enabled = process.env.OTEL_ENABLED === "true";
+  const serviceName = process.env.OTEL_SERVICE_NAME || "unknown-service";
+  const logLevel = (process.env.OTEL_LOG_LEVEL ||
+    "info") as ObservabilityConfig["logLevel"];
+  const exporter = (process.env.OTEL_EXPORTER ||
+    "console") as ObservabilityConfig["exporter"];
 
   const config: ObservabilityConfig = {
     enabled,
     serviceName,
     logLevel,
     exporter,
-  }
+  };
 
   // Add Axiom config if using Axiom exporter
-  if (exporter === 'axiom') {
-    const apiToken = process.env.AXIOM_API_TOKEN
-    const dataset = process.env.AXIOM_DATASET
+  if (exporter === "axiom") {
+    const apiToken = process.env.AXIOM_API_TOKEN;
+    const dataset = process.env.AXIOM_DATASET;
 
     if (!apiToken || !dataset) {
       console.warn(
-        'Axiom exporter configured but AXIOM_API_TOKEN or AXIOM_DATASET not set. Falling back to console exporter.'
-      )
-      config.exporter = 'console'
+        "Axiom exporter configured but AXIOM_API_TOKEN or AXIOM_DATASET not set. Falling back to console exporter.",
+      );
+      config.exporter = "console";
     } else {
       config.axiom = {
         apiToken,
         dataset,
-        domain: process.env.AXIOM_DOMAIN || 'api.axiom.co',
-      }
+        domain: process.env.AXIOM_DOMAIN || "api.axiom.co",
+      };
     }
   }
 
-  return config
+  return config;
 }
 
 export function isEnabled(): boolean {
-  return process.env.OTEL_ENABLED === 'true'
+  return process.env.OTEL_ENABLED === "true";
 }
 
-export function shouldLog(level: ObservabilityConfig['logLevel']): boolean {
-  if (!isEnabled()) return false
+export function shouldLog(level: ObservabilityConfig["logLevel"]): boolean {
+  if (!isEnabled()) return false;
 
-  const config = getConfig()
-  const levels: ObservabilityConfig['logLevel'][] = ['debug', 'info', 'warn', 'error']
-  const configLevelIndex = levels.indexOf(config.logLevel)
-  const requestedLevelIndex = levels.indexOf(level)
+  const config = getConfig();
+  const levels: ObservabilityConfig["logLevel"][] = [
+    "debug",
+    "info",
+    "warn",
+    "error",
+  ];
+  const configLevelIndex = levels.indexOf(config.logLevel);
+  const requestedLevelIndex = levels.indexOf(level);
 
-  return requestedLevelIndex >= configLevelIndex
+  return requestedLevelIndex >= configLevelIndex;
 }

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -4,8 +4,8 @@ import {
   ConsoleSpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { getConfig, isEnabled } from "./config";
-import { logger } from "./utils/logging";
+import { getConfig, isEnabled } from "./config.js";
+import { logger } from "./utils/logging.js";
 
 export function initializeObservability(): void {
   if (!isEnabled()) {
@@ -84,7 +84,7 @@ export function initializeObservability(): void {
 }
 
 // Export utilities
-export * from "./utils/tracing";
-export * from "./utils/logging";
-export { getConfig, isEnabled } from "./config";
-export type { ObservabilityConfig } from "./config";
+export * from "./utils/tracing.js";
+export * from "./utils/logging.js";
+export { getConfig, isEnabled } from "./config.js";
+export type { ObservabilityConfig } from "./config.js";

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,55 +1,58 @@
-import { registerOTel } from '@vercel/otel'
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
-import { getConfig, isEnabled } from './config'
-import { logger } from './utils/logging'
+import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { getConfig, isEnabled } from "./config";
+import { logger } from "./utils/logging";
 
 export function initializeObservability(): void {
   if (!isEnabled()) {
-    logger.debug('OpenTelemetry is disabled')
-    return
+    logger.debug("OpenTelemetry is disabled");
+    return;
   }
 
-  const config = getConfig()
-  logger.info(`Initializing OpenTelemetry for service: ${config.serviceName}`)
+  const config = getConfig();
+  logger.info(`Initializing OpenTelemetry for service: ${config.serviceName}`);
 
   try {
     // Create the appropriate span processor based on configuration
-    let spanProcessor: SimpleSpanProcessor | null = null
+    let spanProcessor: SimpleSpanProcessor | null = null;
 
     switch (config.exporter) {
-      case 'console':
-        logger.debug('Creating console exporter for local development')
-        spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter())
-        break
-      case 'axiom':
+      case "console":
+        logger.debug("Creating console exporter for local development");
+        spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter());
+        break;
+      case "axiom":
         if (config.axiom) {
-          const { apiToken, dataset, domain } = config.axiom
-          logger.debug(`Creating Axiom exporter for dataset: ${dataset}`)
-          
+          const { apiToken, dataset, domain } = config.axiom;
+          logger.debug(`Creating Axiom exporter for dataset: ${dataset}`);
+
           const exporter = new OTLPTraceExporter({
             url: `https://${domain}/v1/traces`,
             headers: {
               Authorization: `Bearer ${apiToken}`,
-              'X-Axiom-Dataset': dataset,
+              "X-Axiom-Dataset": dataset,
             },
             timeoutMillis: 30000,
-          })
-          
-          spanProcessor = new SimpleSpanProcessor(exporter)
+          });
+
+          spanProcessor = new SimpleSpanProcessor(exporter);
         } else {
-          logger.warn('Axiom configuration missing, falling back to console')
-          spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter())
+          logger.warn("Axiom configuration missing, falling back to console");
+          spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter());
         }
-        break
-      case 'none':
-        logger.info('No exporter configured')
-        return
+        break;
+      case "none":
+        logger.info("No exporter configured");
+        return;
     }
 
     if (!spanProcessor) {
-      logger.error('Failed to create span processor')
-      return
+      logger.error("Failed to create span processor");
+      return;
     }
 
     // Initialize using @vercel/otel
@@ -57,20 +60,31 @@ export function initializeObservability(): void {
       serviceName: config.serviceName,
       spanProcessors: [spanProcessor],
       attributes: {
-        environment: process.env.NODE_ENV || 'development',
+        environment: process.env.NODE_ENV || "development",
+        "service.version": process.env.npm_package_version || "unknown",
       },
-    })
+    });
 
-    logger.info('OpenTelemetry initialized successfully')
+    logger.info("OpenTelemetry initialized successfully");
+
+    // Register shutdown hooks to ensure spans are flushed
+    const shutdown = async () => {
+      logger.info("Shutting down OpenTelemetry");
+      // Give time for spans to be exported
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    };
+
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
   } catch (error) {
-    logger.error('Failed to initialize OpenTelemetry', {
+    logger.error("Failed to initialize OpenTelemetry", {
       error: error instanceof Error ? error.message : String(error),
-    })
+    });
   }
 }
 
 // Export utilities
-export * from './utils/tracing'
-export * from './utils/logging'
-export { getConfig, isEnabled } from './config'
-export type { ObservabilityConfig } from './config'
+export * from "./utils/tracing";
+export * from "./utils/logging";
+export { getConfig, isEnabled } from "./config";
+export type { ObservabilityConfig } from "./config";

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,76 @@
+import { registerOTel } from '@vercel/otel'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { getConfig, isEnabled } from './config'
+import { logger } from './utils/logging'
+
+export function initializeObservability(): void {
+  if (!isEnabled()) {
+    logger.debug('OpenTelemetry is disabled')
+    return
+  }
+
+  const config = getConfig()
+  logger.info(`Initializing OpenTelemetry for service: ${config.serviceName}`)
+
+  try {
+    // Create the appropriate span processor based on configuration
+    let spanProcessor: SimpleSpanProcessor | null = null
+
+    switch (config.exporter) {
+      case 'console':
+        logger.debug('Creating console exporter for local development')
+        spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter())
+        break
+      case 'axiom':
+        if (config.axiom) {
+          const { apiToken, dataset, domain } = config.axiom
+          logger.debug(`Creating Axiom exporter for dataset: ${dataset}`)
+          
+          const exporter = new OTLPTraceExporter({
+            url: `https://${domain}/v1/traces`,
+            headers: {
+              Authorization: `Bearer ${apiToken}`,
+              'X-Axiom-Dataset': dataset,
+            },
+            timeoutMillis: 30000,
+          })
+          
+          spanProcessor = new SimpleSpanProcessor(exporter)
+        } else {
+          logger.warn('Axiom configuration missing, falling back to console')
+          spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter())
+        }
+        break
+      case 'none':
+        logger.info('No exporter configured')
+        return
+    }
+
+    if (!spanProcessor) {
+      logger.error('Failed to create span processor')
+      return
+    }
+
+    // Initialize using @vercel/otel
+    registerOTel({
+      serviceName: config.serviceName,
+      spanProcessors: [spanProcessor],
+      attributes: {
+        environment: process.env.NODE_ENV || 'development',
+      },
+    })
+
+    logger.info('OpenTelemetry initialized successfully')
+  } catch (error) {
+    logger.error('Failed to initialize OpenTelemetry', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+// Export utilities
+export * from './utils/tracing'
+export * from './utils/logging'
+export { getConfig, isEnabled } from './config'
+export type { ObservabilityConfig } from './config'

--- a/packages/observability/src/utils/logging.ts
+++ b/packages/observability/src/utils/logging.ts
@@ -1,6 +1,6 @@
 import { trace } from "@opentelemetry/api";
-import { shouldLog } from "../config";
-import type { ObservabilityConfig } from "../config";
+import { shouldLog } from "../config.js";
+import type { ObservabilityConfig } from "../config.js";
 
 interface LogContext {
   traceId?: string;

--- a/packages/observability/src/utils/logging.ts
+++ b/packages/observability/src/utils/logging.ts
@@ -1,62 +1,62 @@
-import { trace } from '@opentelemetry/api'
-import { shouldLog } from '../config'
-import type { ObservabilityConfig } from '../config'
+import { trace } from "@opentelemetry/api";
+import { shouldLog } from "../config";
+import type { ObservabilityConfig } from "../config";
 
 interface LogContext {
-  traceId?: string
-  spanId?: string
-  [key: string]: unknown
+  traceId?: string;
+  spanId?: string;
+  [key: string]: unknown;
 }
 
 function getTraceContext(): { traceId: string; spanId: string } | null {
-  const span = trace.getActiveSpan()
-  if (!span) return null
+  const span = trace.getActiveSpan();
+  if (!span) return null;
 
-  const spanContext = span.spanContext()
+  const spanContext = span.spanContext();
   return {
     traceId: spanContext.traceId,
     spanId: spanContext.spanId,
-  }
+  };
 }
 
 function formatLog(
-  level: ObservabilityConfig['logLevel'],
+  level: ObservabilityConfig["logLevel"],
   message: string,
-  context?: LogContext
+  context?: LogContext,
 ): string {
-  const traceContext = getTraceContext()
+  const traceContext = getTraceContext();
   const fullContext = {
     ...context,
     ...traceContext,
-  }
+  };
 
-  const timestamp = new Date().toISOString()
+  const timestamp = new Date().toISOString();
   return `[${timestamp}] [${level.toUpperCase()}] ${message} ${
-    Object.keys(fullContext).length > 0 ? JSON.stringify(fullContext) : ''
-  }`
+    Object.keys(fullContext).length > 0 ? JSON.stringify(fullContext) : ""
+  }`;
 }
 
 export function debug(message: string, context?: LogContext): void {
-  if (shouldLog('debug')) {
-    console.log(formatLog('debug', message, context))
+  if (shouldLog("debug")) {
+    console.log(formatLog("debug", message, context));
   }
 }
 
 export function info(message: string, context?: LogContext): void {
-  if (shouldLog('info')) {
-    console.log(formatLog('info', message, context))
+  if (shouldLog("info")) {
+    console.log(formatLog("info", message, context));
   }
 }
 
 export function warn(message: string, context?: LogContext): void {
-  if (shouldLog('warn')) {
-    console.warn(formatLog('warn', message, context))
+  if (shouldLog("warn")) {
+    console.warn(formatLog("warn", message, context));
   }
 }
 
 export function error(message: string, context?: LogContext): void {
-  if (shouldLog('error')) {
-    console.error(formatLog('error', message, context))
+  if (shouldLog("error")) {
+    console.error(formatLog("error", message, context));
   }
 }
 
@@ -65,4 +65,4 @@ export const logger = {
   info,
   warn,
   error,
-}
+};

--- a/packages/observability/src/utils/logging.ts
+++ b/packages/observability/src/utils/logging.ts
@@ -1,0 +1,68 @@
+import { trace } from '@opentelemetry/api'
+import { shouldLog } from '../config'
+import type { ObservabilityConfig } from '../config'
+
+interface LogContext {
+  traceId?: string
+  spanId?: string
+  [key: string]: unknown
+}
+
+function getTraceContext(): { traceId: string; spanId: string } | null {
+  const span = trace.getActiveSpan()
+  if (!span) return null
+
+  const spanContext = span.spanContext()
+  return {
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+  }
+}
+
+function formatLog(
+  level: ObservabilityConfig['logLevel'],
+  message: string,
+  context?: LogContext
+): string {
+  const traceContext = getTraceContext()
+  const fullContext = {
+    ...context,
+    ...traceContext,
+  }
+
+  const timestamp = new Date().toISOString()
+  return `[${timestamp}] [${level.toUpperCase()}] ${message} ${
+    Object.keys(fullContext).length > 0 ? JSON.stringify(fullContext) : ''
+  }`
+}
+
+export function debug(message: string, context?: LogContext): void {
+  if (shouldLog('debug')) {
+    console.log(formatLog('debug', message, context))
+  }
+}
+
+export function info(message: string, context?: LogContext): void {
+  if (shouldLog('info')) {
+    console.log(formatLog('info', message, context))
+  }
+}
+
+export function warn(message: string, context?: LogContext): void {
+  if (shouldLog('warn')) {
+    console.warn(formatLog('warn', message, context))
+  }
+}
+
+export function error(message: string, context?: LogContext): void {
+  if (shouldLog('error')) {
+    console.error(formatLog('error', message, context))
+  }
+}
+
+export const logger = {
+  debug,
+  info,
+  warn,
+  error,
+}

--- a/packages/observability/src/utils/tracing.ts
+++ b/packages/observability/src/utils/tracing.ts
@@ -1,64 +1,76 @@
-import { trace, context, SpanStatusCode } from '@opentelemetry/api'
-import type { Span, SpanOptions, AttributeValue } from '@opentelemetry/api'
+import { trace, context, SpanStatusCode } from "@opentelemetry/api";
+import type { Span, SpanOptions, AttributeValue } from "@opentelemetry/api";
 
-const tracer = trace.getTracer('@workspace/observability', '0.0.0')
+const tracer = trace.getTracer("@workspace/observability", "0.0.0");
 
 export function createSpan(name: string, options?: SpanOptions): Span {
-  return tracer.startSpan(name, options)
+  return tracer.startSpan(name, options);
 }
 
 export async function withSpan<T>(
   name: string,
   fn: (span: Span) => Promise<T>,
-  options?: SpanOptions
+  options?: SpanOptions,
 ): Promise<T> {
-  const span = createSpan(name, options)
+  const span = createSpan(name, options);
 
   try {
-    const result = await context.with(trace.setSpan(context.active(), span), () => fn(span))
-    span.setStatus({ code: SpanStatusCode.OK })
-    return result
+    const result = await context.with(
+      trace.setSpan(context.active(), span),
+      () => fn(span),
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
   } catch (error) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : 'Unknown error',
-    })
-    span.recordException(error as Error)
-    throw error
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    span.recordException(error as Error);
+    throw error;
   } finally {
-    span.end()
+    span.end();
   }
 }
 
 export function withSpanSync<T>(
   name: string,
   fn: (span: Span) => T,
-  options?: SpanOptions
+  options?: SpanOptions,
 ): T {
-  const span = createSpan(name, options)
+  const span = createSpan(name, options);
 
   try {
-    const result = context.with(trace.setSpan(context.active(), span), () => fn(span))
-    span.setStatus({ code: SpanStatusCode.OK })
-    return result
+    const result = context.with(trace.setSpan(context.active(), span), () =>
+      fn(span),
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
   } catch (error) {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: error instanceof Error ? error.message : 'Unknown error',
-    })
-    span.recordException(error as Error)
-    throw error
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    span.recordException(error as Error);
+    throw error;
   } finally {
-    span.end()
+    span.end();
   }
 }
 
-export function setSpanAttribute(span: Span, key: string, value: AttributeValue): void {
-  span.setAttribute(key, value)
+export function setSpanAttribute(
+  span: Span,
+  key: string,
+  value: AttributeValue,
+): void {
+  span.setAttribute(key, value);
 }
 
-export function setSpanAttributes(span: Span, attributes: Record<string, AttributeValue>): void {
+export function setSpanAttributes(
+  span: Span,
+  attributes: Record<string, AttributeValue>,
+): void {
   Object.entries(attributes).forEach(([key, value]) => {
-    span.setAttribute(key, value)
-  })
+    span.setAttribute(key, value);
+  });
 }

--- a/packages/observability/src/utils/tracing.ts
+++ b/packages/observability/src/utils/tracing.ts
@@ -1,0 +1,64 @@
+import { trace, context, SpanStatusCode } from '@opentelemetry/api'
+import type { Span, SpanOptions, AttributeValue } from '@opentelemetry/api'
+
+const tracer = trace.getTracer('@workspace/observability', '0.0.0')
+
+export function createSpan(name: string, options?: SpanOptions): Span {
+  return tracer.startSpan(name, options)
+}
+
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  options?: SpanOptions
+): Promise<T> {
+  const span = createSpan(name, options)
+
+  try {
+    const result = await context.with(trace.setSpan(context.active(), span), () => fn(span))
+    span.setStatus({ code: SpanStatusCode.OK })
+    return result
+  } catch (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
+    span.recordException(error as Error)
+    throw error
+  } finally {
+    span.end()
+  }
+}
+
+export function withSpanSync<T>(
+  name: string,
+  fn: (span: Span) => T,
+  options?: SpanOptions
+): T {
+  const span = createSpan(name, options)
+
+  try {
+    const result = context.with(trace.setSpan(context.active(), span), () => fn(span))
+    span.setStatus({ code: SpanStatusCode.OK })
+    return result
+  } catch (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
+    span.recordException(error as Error)
+    throw error
+  } finally {
+    span.end()
+  }
+}
+
+export function setSpanAttribute(span: Span, key: string, value: AttributeValue): void {
+  span.setAttribute(key, value)
+}
+
+export function setSpanAttributes(span: Span, attributes: Record<string, AttributeValue>): void {
+  Object.entries(attributes).forEach(([key, value]) => {
+    span.setAttribute(key, value)
+  })
+}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@workspace/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/observability/tsup.config.ts
+++ b/packages/observability/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
-  dts: false,
+  dts: true,
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/packages/observability/tsup.config.ts
+++ b/packages/observability/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['node:*'],
+})

--- a/packages/observability/tsup.config.ts
+++ b/packages/observability/tsup.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from 'tsup'
+import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
   dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,
-  external: ['node:*'],
-})
+  external: ["node:*"],
+});

--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -1,28 +1,28 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { Button } from './button'
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Button } from "./button";
 
-describe('Button', () => {
-  it('renders with text', () => {
-    render(<Button>Click me</Button>)
-    expect(screen.getByRole('button')).toHaveTextContent('Click me')
-  })
+describe("Button", () => {
+  it("renders with text", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button")).toHaveTextContent("Click me");
+  });
 
-  it('applies variant classes', () => {
-    render(<Button variant="secondary">Secondary</Button>)
-    const button = screen.getByRole('button')
-    expect(button).toHaveClass('border-input')
-  })
+  it("applies variant classes", () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("border-input");
+  });
 
-  it('applies size classes', () => {
-    render(<Button size="sm">Small</Button>)
-    const button = screen.getByRole('button')
-    expect(button).toHaveClass('h-10')
-  })
+  it("applies size classes", () => {
+    render(<Button size="sm">Small</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("h-10");
+  });
 
-  it('handles disabled state', () => {
-    render(<Button disabled>Disabled</Button>)
-    const button = screen.getByRole('button')
-    expect(button).toBeDisabled()
-  })
-})
+  it("handles disabled state", () => {
+    render(<Button disabled>Disabled</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+  });
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,18 +1,18 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
-    include: ['**/*.test.tsx', '**/*.test.ts'],
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["**/*.test.tsx", "**/*.test.ts"],
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
-})
+});

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/vitest'
+import "@testing-library/jest-dom/vitest";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,10 @@ importers:
         version: 1.1.0
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+      '@workspace/observability':
+        specifier: workspace:*
+        version: link:../../packages/observability
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -149,10 +152,10 @@ importers:
         version: 0.525.0(react@19.1.0)
       next:
         specifier: 15.3.4
-        version: 15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-sanity:
         specifier: ^9.12.0
-        version: 9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+        version: 9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -256,6 +259,46 @@ importers:
       typescript-eslint:
         specifier: ^8.34.1
         version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+
+  packages/observability:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ~1.8.0
+        version: 1.8.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.49.1
+        version: 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources':
+        specifier: ^1.22.0
+        version: 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.49.1
+        version: 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.22.0
+        version: 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.22.0
+        version: 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.22.0
+        version: 1.34.0
+      '@vercel/otel':
+        specifier: ^1.8.0
+        version: 1.13.0(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)(@opentelemetry/instrumentation@0.49.1(@opentelemetry/api@1.8.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.8.0))
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.3
+      '@workspace/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      tsup:
+        specifier: ^8.2.3
+        version: 8.5.0(jiti@2.4.2)(postcss@8.5.6)(typescript@5.7.3)(yaml@2.6.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
 
   packages/typescript-config: {}
 
@@ -1335,6 +1378,15 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@grpc/grpc-js@1.13.4':
+    resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hello-pangea/dnd@18.0.1':
     resolution: {integrity: sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==}
     peerDependencies:
@@ -1643,6 +1695,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
@@ -1783,6 +1838,187 @@ packages:
   '@octokit/types@13.6.2':
     resolution: {integrity: sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==}
 
+  '@opentelemetry/api-logs@0.49.1':
+    resolution: {integrity: sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.8.0':
+    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.22.0':
+    resolution: {integrity: sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.22.0':
+    resolution: {integrity: sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.49.1':
+    resolution: {integrity: sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.49.1':
+    resolution: {integrity: sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.49.1':
+    resolution: {integrity: sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-zipkin@1.22.0':
+    resolution: {integrity: sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.49.1':
+    resolution: {integrity: sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.49.1':
+    resolution: {integrity: sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.49.1':
+    resolution: {integrity: sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/otlp-proto-exporter-base@0.49.1':
+    resolution: {integrity: sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/otlp-transformer@0.49.1':
+    resolution: {integrity: sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+
+  '@opentelemetry/propagator-b3@1.22.0':
+    resolution: {integrity: sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.22.0':
+    resolution: {integrity: sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.22.0':
+    resolution: {integrity: sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.49.1':
+    resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.9.0'
+      '@opentelemetry/api-logs': '>=0.39.1'
+
+  '@opentelemetry/sdk-metrics@1.22.0':
+    resolution: {integrity: sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+
+  '@opentelemetry/sdk-node@0.49.1':
+    resolution: {integrity: sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+
+  '@opentelemetry/sdk-trace-base@1.22.0':
+    resolution: {integrity: sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.22.0':
+    resolution: {integrity: sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.22.0':
+    resolution: {integrity: sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.34.0':
+    resolution: {integrity: sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==}
+    engines: {node: '>=14'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1829,6 +2065,36 @@ packages:
   '@portabletext/types@2.0.13':
     resolution: {integrity: sha512-5xk5MSyQU9CrDho3Rsguj38jhijhD36Mk8S6mZo3huv6PM+t4M/5kJN2KFIxgvt4ONpvOEs1pVIZAV0cL0Vi+Q==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -2826,6 +3092,9 @@ packages:
   '@types/shallow-equals@1.0.3':
     resolution: {integrity: sha512-xZx/hZsf1p9J5lGN/nGTsuW/chJCdlyGxilwg1TS78rygBCU5bpY50zZiFcIimlnl0p41kAyaASsy0bqU7WyBA==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
   '@types/speakingurl@13.0.6':
     resolution: {integrity: sha512-ywkRHNHBwq0mFs/2HRgW6TEBAzH66G8f2Txzh1aGR0UC9ZoAUHfHxLZGDhwMpck4BpSnB61eNFIFmlV+TJ+KUA==}
 
@@ -3002,6 +3271,18 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@vercel/otel@1.13.0':
+    resolution: {integrity: sha512-esRkt470Y2jRK1B1g7S1vkt4Csu44gp83Zpu8rIyPoqy2BKgk4z7ik1uSMswzi45UogLHFl6yR5TauDurBQi4Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
+      '@opentelemetry/api-logs': '>=0.46.0 <0.200.0'
+      '@opentelemetry/instrumentation': '>=0.46.0 <0.200.0'
+      '@opentelemetry/resources': '>=1.19.0 <2.0.0'
+      '@opentelemetry/sdk-logs': '>=0.46.0 <0.200.0'
+      '@opentelemetry/sdk-metrics': '>=1.19.0 <2.0.0'
+      '@opentelemetry/sdk-trace-base': '>=1.19.0 <2.0.0'
+
   '@vercel/stega@0.1.2':
     resolution: {integrity: sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA==}
 
@@ -3066,6 +3347,12 @@ packages:
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  acorn-import-assertions@1.9.0:
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3371,6 +3658,12 @@ packages:
   builtins@1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -3463,12 +3756,19 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -3587,9 +3887,16 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-table-printer@2.12.1:
     resolution: {integrity: sha512-wKGOQRRvdnd89pCeH96e2Fn4wkbenSP6LMHfjfyNLMbGuHEFbMqQNuxXqd0oXG9caIOQ1FTvc5Uijp9/4jujnQ==}
@@ -4320,6 +4627,9 @@ packages:
   find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -4685,6 +4995,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.7.1:
+    resolution: {integrity: sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -5003,6 +5316,10 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5139,6 +5456,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -5162,6 +5483,9 @@ packages:
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
@@ -5177,6 +5501,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -5199,6 +5526,9 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -5382,8 +5712,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
@@ -5817,6 +6153,9 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   pluralize-esm@9.0.5:
     resolution: {integrity: sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==}
     engines: {node: '>=14.0.0'}
@@ -5855,6 +6194,24 @@ packages:
       postcss:
         optional: true
       ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-nested@6.2.0:
@@ -5927,6 +6284,10 @@ packages:
 
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
+
+  protobufjs@7.5.3:
+    resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
@@ -6188,6 +6549,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6255,6 +6620,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -6505,6 +6874,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -6594,6 +6966,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
 
   space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -6928,9 +7304,16 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -6987,6 +7370,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.0:
+    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -7092,6 +7494,9 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -7365,6 +7770,9 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -7380,6 +7788,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -8747,6 +9158,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@grpc/grpc-js@1.13.4':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.3
+      yargs: 17.7.2
+
   '@hello-pangea/dnd@18.0.1(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
@@ -9020,6 +9443,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@juggle/resize-observer@3.4.0': {}
 
   '@lezer/common@1.2.3': {}
@@ -9165,6 +9590,217 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 22.2.0
 
+  '@opentelemetry/api-logs@0.49.1':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+
+  '@opentelemetry/api@1.8.0': {}
+
+  '@opentelemetry/api@1.9.0':
+    optional: true
+
+  '@opentelemetry/context-async-hooks@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+
+  '@opentelemetry/core@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/semantic-conventions': 1.22.0
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-proto-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/exporter-zipkin@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+
+  '@opentelemetry/instrumentation@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.7.1
+      require-in-the-middle: 7.5.2
+      semver: 7.7.2
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      protobufjs: 7.5.3
+
+  '@opentelemetry/otlp-proto-exporter-base@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      protobufjs: 7.5.3
+
+  '@opentelemetry/otlp-transformer@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/propagator-b3@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/propagator-jaeger@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/resources@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+
+  '@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      lodash.merge: 4.6.2
+
+  '@opentelemetry/sdk-node@0.49.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/exporter-zipkin': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-node': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.22.0(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/context-async-hooks': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/propagator-b3': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/propagator-jaeger': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+      semver: 7.7.2
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.8.0)':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.8.0)
+      semver: 7.7.2
+
+  '@opentelemetry/semantic-conventions@1.22.0': {}
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.34.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -9226,6 +9862,29 @@ snapshots:
       '@portabletext/types': 2.0.13
 
   '@portabletext/types@2.0.13': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -9996,13 +10655,13 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/next-loader@1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@sanity/next-loader@1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@sanity/client': 7.6.0
       '@sanity/comlink': 3.0.5
       '@sanity/presentation-comlink': 1.0.21(@sanity/client@7.6.0(debug@4.4.0))(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))
       dequal: 2.0.3
-      next: 15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       use-effect-event: 1.0.2(react@19.1.0)
     transitivePeerDependencies:
@@ -10325,7 +10984,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.4(react@19.1.0)
@@ -10348,7 +11007,7 @@ snapshots:
       xstate: 5.19.2
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -10603,6 +11262,8 @@ snapshots:
 
   '@types/shallow-equals@1.0.3': {}
 
+  '@types/shimmer@1.2.0': {}
+
   '@types/speakingurl@13.0.6': {}
 
   '@types/stylis@4.2.5': {}
@@ -10843,6 +11504,16 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
+  '@vercel/otel@1.13.0(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)(@opentelemetry/instrumentation@0.49.1(@opentelemetry/api@1.8.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.8.0))':
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.8.0)
+
   '@vercel/stega@0.1.2': {}
 
   '@vitejs/plugin-react@4.6.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))':
@@ -10933,6 +11604,10 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  acorn-import-assertions@1.9.0(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -11270,6 +11945,11 @@ snapshots:
 
   builtins@1.0.3: {}
 
+  bundle-require@5.1.0(esbuild@0.25.5):
+    dependencies:
+      esbuild: 0.25.5
+      load-tsconfig: 0.2.5
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -11388,9 +12068,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -11507,6 +12193,8 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
+  confbox@0.1.8: {}
+
   configstore@5.0.1:
     dependencies:
       dot-prop: 5.3.0
@@ -11515,6 +12203,8 @@ snapshots:
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
+
+  consola@3.4.2: {}
 
   console-table-printer@2.12.1:
     dependencies:
@@ -12438,6 +13128,12 @@ snapshots:
       micromatch: 4.0.8
       pkg-dir: 4.2.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      rollup: 4.40.2
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
@@ -12864,6 +13560,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@1.7.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-assertions: 1.9.0(acorn@8.15.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -13170,6 +13873,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -13343,6 +14048,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  load-tsconfig@0.2.5: {}
+
   load-yaml-file@0.2.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -13369,6 +14076,8 @@ snapshots:
 
   lodash-es@4.17.21: {}
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.castarray@4.4.0: {}
 
   lodash.debounce@4.0.8: {}
@@ -13378,6 +14087,8 @@ snapshots:
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.sortby@4.7.0: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -13400,6 +14111,8 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       is-unicode-supported: 1.3.0
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -13568,7 +14281,16 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  mlly@1.7.4:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
+
   module-alias@2.2.3: {}
+
+  module-details-from-path@1.0.4: {}
 
   moment@2.30.1: {}
 
@@ -13614,20 +14336,20 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-sanity@9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3):
+  next-sanity@9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3):
     dependencies:
       '@portabletext/react': 3.2.1(react@19.1.0)
       '@sanity/client': 7.6.0
       '@sanity/icons': 3.7.4(react@19.1.0)
-      '@sanity/next-loader': 1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@sanity/next-loader': 1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@sanity/preview-kit': 6.1.1(@sanity/types@3.93.0(@types/react@19.1.8))(react@19.1.0)
       '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.6.0(debug@4.4.0))
       '@sanity/types': 3.93.0(@types/react@19.1.8)
       '@sanity/ui': 2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@sanity/visual-editing': 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+      '@sanity/visual-editing': 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       groq: 3.88.2
       history: 5.3.0
-      next: 15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       sanity: 3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1)
@@ -13647,7 +14369,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.3.4(@babel/core@7.27.4)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.4
       '@swc/counter': 0.1.3
@@ -13667,6 +14389,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.4
       '@next/swc-win32-arm64-msvc': 15.3.4
       '@next/swc-win32-x64-msvc': 15.3.4
+      '@opentelemetry/api': 1.9.0
       babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
@@ -14033,6 +14756,12 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.4
+      pathe: 2.0.3
+
   pluralize-esm@9.0.5: {}
 
   pluralize@8.0.0: {}
@@ -14062,6 +14791,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@24.0.3)(typescript@5.7.3)
+
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.6.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.6
+      yaml: 2.6.1
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -14137,6 +14874,21 @@ snapshots:
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
+
+  protobufjs@7.5.3:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 24.0.3
+      long: 5.3.2
 
   proxy-agent@6.5.0:
     dependencies:
@@ -14428,6 +15180,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  readdirp@4.1.2: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -14509,6 +15263,14 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
 
   requires-port@1.0.0: {}
 
@@ -14990,6 +15752,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shimmer@1.2.1: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -15099,6 +15863,10 @@ snapshots:
   source-map@0.5.7: {}
 
   source-map@0.6.1: {}
+
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
 
   space-separated-tokens@1.1.5: {}
 
@@ -15500,9 +16268,15 @@ snapshots:
     dependencies:
       tldts: 6.1.71
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
 
   trim-newlines@3.0.1: {}
 
@@ -15554,6 +16328,34 @@ snapshots:
   tslib@2.6.2: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.0(jiti@2.4.2)(postcss@8.5.6)(typescript@5.7.3)(yaml@2.6.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.5)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.1(supports-color@8.1.1)
+      esbuild: 0.25.5
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.6.1)
+      resolve-from: 5.0.0
+      rollup: 4.40.2
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -15664,6 +16466,8 @@ snapshots:
       - supports-color
 
   typescript@5.7.3: {}
+
+  ufo@1.6.1: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -15916,6 +16720,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@4.0.2: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -15928,6 +16734,12 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,13 +131,13 @@ importers:
         version: 2.2.1
       '@sanity/client':
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.0(debug@4.4.1)
       '@sanity/image-url':
         specifier: ^1.1.0
         version: 1.1.0
       '@sanity/visual-editing':
         specifier: ^2.15.0
-        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+        version: 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       '@workspace/observability':
         specifier: workspace:*
         version: link:../../packages/observability
@@ -152,10 +152,10 @@ importers:
         version: 0.525.0(react@19.1.0)
       next:
         specifier: 15.3.4
-        version: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-sanity:
         specifier: ^9.12.0
-        version: 9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+        version: 9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -175,6 +175,9 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ~1.8.0
+        version: 1.8.0
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -1844,10 +1847,6 @@ packages:
 
   '@opentelemetry/api@1.8.0':
     resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/context-async-hooks@1.22.0':
@@ -9596,9 +9595,6 @@ snapshots:
 
   '@opentelemetry/api@1.8.0': {}
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
-
   '@opentelemetry/context-async-hooks@1.22.0(@opentelemetry/api@1.8.0)':
     dependencies:
       '@opentelemetry/api': 1.8.0
@@ -9815,12 +9811,12 @@ snapshots:
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
 
-  '@portabletext/editor@1.55.0(@sanity/schema@3.93.0(@types/react@19.1.8))(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)':
+  '@portabletext/editor@1.55.0(@sanity/schema@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)':
     dependencies:
       '@portabletext/block-tools': 1.1.31(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@types/react@19.1.8)
       '@portabletext/patches': 1.1.5
       '@portabletext/to-html': 2.0.14
-      '@sanity/schema': 3.93.0(@types/react@19.1.8)
+      '@sanity/schema': 3.93.0(@types/react@19.1.8)(debug@4.4.0)
       '@sanity/types': 3.93.0(@types/react@19.1.8)
       '@xstate/react': 6.0.0(@types/react@19.1.8)(react@19.1.0)(xstate@5.20.0)
       debug: 4.4.1(supports-color@8.1.1)
@@ -10391,7 +10387,7 @@ snapshots:
   '@sanity/client@7.6.0':
     dependencies:
       '@sanity/eventsource': 5.0.2
-      get-it: 8.6.9
+      get-it: 8.6.9(debug@4.4.1)
       nanoid: 3.3.11
       rxjs: 7.8.2
     transitivePeerDependencies:
@@ -10655,13 +10651,13 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/next-loader@1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@sanity/next-loader@1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@sanity/client': 7.6.0
       '@sanity/comlink': 3.0.5
       '@sanity/presentation-comlink': 1.0.21(@sanity/client@7.6.0(debug@4.4.0))(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))
       dequal: 2.0.3
-      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       use-effect-event: 1.0.2(react@19.1.0)
     transitivePeerDependencies:
@@ -10984,7 +10980,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 3.93.0(@types/react@19.1.8)
 
-  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
+  '@sanity/visual-editing@2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
     dependencies:
       '@sanity/comlink': 3.0.5
       '@sanity/icons': 3.7.4(react@19.1.0)
@@ -11007,7 +11003,7 @@ snapshots:
       xstate: 5.19.2
     optionalDependencies:
       '@sanity/client': 7.6.0
-      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -13252,17 +13248,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-it@8.6.9:
-    dependencies:
-      '@types/follow-redirects': 1.14.4
-      decompress-response: 7.0.0
-      follow-redirects: 1.15.9(debug@4.4.1)
-      is-retry-allowed: 2.2.0
-      through2: 4.0.2
-      tunnel-agent: 0.6.0
-    transitivePeerDependencies:
-      - debug
-
   get-it@8.6.9(debug@4.4.0):
     dependencies:
       '@types/follow-redirects': 1.14.4
@@ -14336,20 +14321,20 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-sanity@9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3):
+  next-sanity@9.12.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/icons@3.7.4(react@19.1.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@sanity/ui@2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(sanity@3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3):
     dependencies:
       '@portabletext/react': 3.2.1(react@19.1.0)
       '@sanity/client': 7.6.0
       '@sanity/icons': 3.7.4(react@19.1.0)
-      '@sanity/next-loader': 1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@sanity/next-loader': 1.6.2(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@sanity/preview-kit': 6.1.1(@sanity/types@3.93.0(@types/react@19.1.8))(react@19.1.0)
       '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.6.0(debug@4.4.0))
       '@sanity/types': 3.93.0(@types/react@19.1.8)
       '@sanity/ui': 2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@sanity/visual-editing': 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+      '@sanity/visual-editing': 2.15.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.6.0)(@sanity/types@3.93.0(@types/react@19.1.8))(next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@19.0.0)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
       groq: 3.88.2
       history: 5.3.0
-      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       sanity: 3.93.0(@emotion/is-prop-valid@1.2.2)(@types/node@24.0.3)(@types/react@19.1.8)(immer@10.1.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1)
@@ -14369,7 +14354,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.4(@babel/core@7.27.4)(@opentelemetry/api@1.8.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.4
       '@swc/counter': 0.1.3
@@ -14389,7 +14374,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.4
       '@next/swc-win32-arm64-msvc': 15.3.4
       '@next/swc-win32-x64-msvc': 15.3.4
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.8.0
       babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.2
     transitivePeerDependencies:
@@ -15494,14 +15479,14 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.1.0)
       '@juggle/resize-observer': 3.4.0
       '@portabletext/block-tools': 1.1.31(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@types/react@19.1.8)
-      '@portabletext/editor': 1.55.0(@sanity/schema@3.93.0(@types/react@19.1.8))(@sanity/types@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)
+      '@portabletext/editor': 1.55.0(@sanity/schema@3.93.0(@types/react@19.1.8)(debug@4.4.0))(@sanity/types@3.93.0(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)
       '@portabletext/react': 3.2.1(react@19.1.0)
       '@portabletext/toolkit': 2.0.17
       '@rexxars/react-json-inspector': 9.0.1(react@19.1.0)
       '@sanity/asset-utils': 2.2.1
       '@sanity/bifur-client': 0.4.1
       '@sanity/cli': 3.93.0(@types/node@24.0.3)(@types/react@19.1.8)(react@19.1.0)(terser@5.37.0)(typescript@5.7.3)(yaml@2.6.1)
-      '@sanity/client': 7.6.0
+      '@sanity/client': 7.6.0(debug@4.4.0)
       '@sanity/color': 3.0.6
       '@sanity/comlink': 3.0.5
       '@sanity/diff': 3.93.0
@@ -15523,7 +15508,7 @@ snapshots:
       '@sanity/schema': 3.93.0(@types/react@19.1.8)(debug@4.4.0)
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@19.1.8)(debug@4.4.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
       '@sanity/telemetry': 0.8.1(react@19.1.0)
-      '@sanity/types': 3.93.0(@types/react@19.1.8)
+      '@sanity/types': 3.93.0(@types/react@19.1.8)(debug@4.4.0)
       '@sanity/ui': 2.16.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@sanity/util': 3.93.0(@types/react@19.1.8)(debug@4.4.0)
       '@sanity/uuid': 3.0.2

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Kill any existing processes on the dev ports
+echo "Cleaning up existing processes..."
+lsof -ti:3000,3333 | xargs kill -9 2>/dev/null || true
+
+# Wait a moment for ports to be released
+sleep 2
+
+# Start turbo dev with no-daemon flag to prevent background process issues
+echo "Starting development servers..."
+exec turbo dev --no-daemon

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,14 @@
     "VERCEL_URL",
     "VERCEL_PROJECT_PRODUCTION_URL",
     "VERCEL_ENV",
-    "NODE_ENV"
+    "NODE_ENV",
+    "OTEL_ENABLED",
+    "OTEL_SERVICE_NAME",
+    "OTEL_LOG_LEVEL",
+    "OTEL_EXPORTER",
+    "AXIOM_API_TOKEN",
+    "AXIOM_DATASET",
+    "AXIOM_DOMAIN"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Implements comprehensive OpenTelemetry integration for distributed tracing in local development
- Adds automatic tracing for all Sanity queries with zero overhead when disabled
- Supports both console and Axiom cloud exporters for flexible telemetry analysis

## Test plan
- [ ] Run `pnpm dev` and verify telemetry logs in console with default settings
- [ ] Visit http://localhost:3000/api/test-telemetry to test telemetry endpoint
- [ ] Set `OTEL_ENABLED=false` and verify no telemetry overhead
- [ ] Configure Axiom credentials and verify traces appear in Axiom dashboard
- [ ] Verify all Sanity queries are automatically traced
- [ ] Check that dev server starts without timeouts using `pnpm start`

## Changes
- Added `@vercel/otel` and OpenTelemetry packages
- Created observability package with configurable exporters
- Implemented automatic tracing wrapper for sanityFetch
- Added instrumentation.ts for Next.js integration
- Created test and debug endpoints
- Updated documentation with observability guide
- Fixed TurboRepo timeout issues for Claude Code

Closes #25